### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,13 @@ import { componentize } from '@bytecodealliance/componentize-js';
 import { writeFile } from 'node:fs/promises';
 
 const { component } = await componentize(`
-  export function fn () {}
+  export function hello (name) {
+    return \`Hello \${name}\`;
+  }
 `, `
-  default world test {
-    export fn: func()
+  package local:hello;
+  world hello {
+    export hello: func(name: string) -> string;
   }
 `);
 


### PR DESCRIPTION
The WIT example in the README isn't correct anymore. I pulled the code from `EXAMPLE.md`.