### PR TITLE
fix: drops for borrows

### DIFF
--- a/test/cases/resource-borrow-import/source.js
+++ b/test/cases/resource-borrow-import/source.js
@@ -1,19 +1,17 @@
 import { Thing, foo } from "test:test/resource-borrow-import";
 
-const disposeSymbol = Symbol.dispose || Symbol.for('dispose');
-
 export function test(value) {
     return foo(new Thing(value + 1)) + 4;
 }
 
 export function testBorrow(value) {
     const out = foo(value) + 6;
-    value[disposeSymbol]();
+    value[Symbol.dispose]();
     return out;
 }
 
 export function testBorrowEarlyDrop(value) {
     const result = foo(value) + 8;
-    value[disposeSymbol]();
+    value[Symbol.dispose]();
     return result;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -151,7 +151,7 @@ suite('Bindings', () => {
           name,
           map,
           wasiShim: true,
-          validLiftingOptimization: true,
+          validLiftingOptimization: false,
         });
 
         await mkdir(new URL(`./output/${name}/interfaces`, import.meta.url), {


### PR DESCRIPTION
Fixes implicit drop support for borrows using the JCO PR in https://github.com/bytecodealliance/jco/pull/381.

Still on the GitHub reference for now until the next JCO release.