### PR TITLE
deps: use StarlingMonkey engine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         submodules: recursive
 
     - name: Install Rust
-      run: rustup update stable --no-self-update && rustup default stable
+      run: rustup update stable --no-self-update && rustup default 1.68.2
 
     - name: Install wasm32-unknown-unknown target
       run: rustup target add wasm32-unknown-unknown
@@ -57,28 +57,28 @@ jobs:
         curl -sS -L "https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz" | tar xzf - &&
         echo "$PWD/binaryen-version_${BINARYEN_VERSION}/bin" >> $GITHUB_PATH
 
-    - name: "Install wasi-sdk-20 (linux)"
-      run: |
-        set -x
-        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz
-        tar xf wasi-sdk-20.0-linux.tar.gz
-        sudo mkdir -p /opt/wasi-sdk
-        sudo mv wasi-sdk-20.0/* /opt/wasi-sdk/
+    # - name: "Install wasi-sdk-20 (linux)"
+    #   run: |
+    #     set -x
+    #     curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz
+    #     tar xf wasi-sdk-20.0-linux.tar.gz
+    #     sudo mkdir -p /opt/wasi-sdk
+    #     sudo mv wasi-sdk-20.0/* /opt/wasi-sdk/
 
     - uses: actions/setup-node@v2
       with:
         node-version: '20'
 
-    - name: Cache wasm-tools
-      id: wasm-tools-cache
-      uses: actions/cache@v3
-      with:
-        path: /home/runner/.cargo/bin/wasm-tools
-        key: crate-cache-wasm-tools
+    # - name: Cache wasm-tools
+    #   id: wasm-tools-cache
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: /home/runner/.cargo/bin/wasm-tools
+    #     key: crate-cache-wasm-tools
 
-    - name: "Install wasm-tools"
-      if: steps.wasm-tools-cache.outputs.cache-hit != 'true'
-      run: cargo install wasm-tools
+    # - name: "Install wasm-tools"
+    #   if: steps.wasm-tools-cache.outputs.cache-hit != 'true'
+    #   run: cargo install wasm-tools
 
     # - name: gecko-dev hash
     #   id: gecko-dev-hash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,32 +80,32 @@ jobs:
       if: steps.wasm-tools-cache.outputs.cache-hit != 'true'
       run: cargo install wasm-tools
 
-    - name: gecko-dev hash
-      id: gecko-dev-hash
-      run: cd deps/js-compute-runtime/runtime/spidermonkey/gecko-dev && echo "GECKO_DEV_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      shell: bash
+    # - name: gecko-dev hash
+    #   id: gecko-dev-hash
+    #   run: cd deps/js-compute-runtime/runtime/spidermonkey/gecko-dev && echo "GECKO_DEV_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+    #   shell: bash
 
-    - name: Cache Spidermonkey
-      uses: actions/cache@v3
-      id: sm-cache
-      with:
-        path: deps/js-compute-runtime/runtime/spidermonkey/release
-        key: cache-${{ hashFiles(
-            'deps/js-compute-runtime/runtime/spidermonkey/build-engine.sh',
-            'deps/js-compute-runtime/runtime/spidermonkey/object-files.list'
-          ) }}-${{ steps.gecko-dev-hash.outputs.GECKO_DEV_HASH }}
+    # - name: Cache Spidermonkey
+    #   uses: actions/cache@v3
+    #   id: sm-cache
+    #   with:
+    #     path: deps/js-compute-runtime/runtime/spidermonkey/release
+    #     key: cache-${{ hashFiles(
+    #         'deps/js-compute-runtime/runtime/spidermonkey/build-engine.sh',
+    #         'deps/js-compute-runtime/runtime/spidermonkey/object-files.list'
+    #       ) }}-${{ steps.gecko-dev-hash.outputs.GECKO_DEV_HASH }}
 
-    - name: js-compute-runtime hash
-      id: js-compute-runtime-hash
-      run: cd deps/js-compute-runtime/runtime/js-compute-runtime && echo "JS_COMPUTE_RUNTIME_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      shell: bash
+    # - name: js-compute-runtime hash
+    #   id: js-compute-runtime-hash
+    #   run: cd deps/js-compute-runtime/runtime/js-compute-runtime && echo "JS_COMPUTE_RUNTIME_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+    #   shell: bash
 
-    - name: Cache js-compute-runtime
-      uses: actions/cache@v3
-      id: js-compute-runtime
-      with:
-        path: deps/js-compute-runtime/runtime/js-compute-runtime/build
-        key: cache-${{ steps.js-compute-runtime-hash.outputs.GECKO_DEV_HASH }}-${{ steps.js-compute-runtime-hash.outputs.JS_COMPUTE_RUNTIME_HASH }}
+    # - name: Cache js-compute-runtime
+    #   uses: actions/cache@v3
+    #   id: js-compute-runtime
+    #   with:
+    #     path: deps/js-compute-runtime/runtime/js-compute-runtime/build
+    #     key: cache-${{ steps.js-compute-runtime-hash.outputs.GECKO_DEV_HASH }}-${{ steps.js-compute-runtime-hash.outputs.JS_COMPUTE_RUNTIME_HASH }}
 
     - name: Cache Rust dependencies
       uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,10 @@ jobs:
         submodules: recursive
 
     - name: Install Rust
-      run: rustup update stable --no-self-update |
-        rustup default 1.68.2 |
-        rustup target add wasm32-unknown-unknown |
+      run: |
+        rustup update stable --no-self-update
+        rustup default 1.68.2
+        rustup target add wasm32-unknown-unknown
         rustup target add wasm32-wasi
 
     - uses: actions/setup-node@v2
@@ -62,9 +63,9 @@ jobs:
 
     - name: Test Example
       run: |
-        rustup default stable |
-        rustup target add wasm32-unknown-unknown |
-        cd example && npm run build && ./test.sh |
+        rustup default stable
+        rustup target add wasm32-unknown-unknown
+        cd example && npm run build && ./test.sh
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,13 @@ jobs:
     - name: Install NPM packages
       run: npm install
 
+    - name: Cache StarlingMonkey
+      uses: actions/cache@v3
+      id: starlingmonkey-build
+      with:
+        path: build-release
+        key: engine-build-${{ hashFiles('.git/modules/StarlingMonkey/FETCH_HEAD') }}
+
     - name: Build
       run: npm run build
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,83 +29,14 @@ jobs:
         submodules: recursive
 
     - name: Install Rust
-      run: rustup update stable --no-self-update && rustup default 1.68.2
-
-    - name: Install wasm32-unknown-unknown target
-      run: rustup target add wasm32-unknown-unknown
-
-    - name: Install wasm32-wasi target
-      run: rustup target add wasm32-wasi
-
-    # - run: |
-    #     curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz -L | tar xzvf -
-    #     echo "WASI_SDK_PATH=`pwd`/wasi-sdk-16.0" >> $GITHUB_ENV
-    #   if : matrix.os == 'ubuntu-latest'
-    # - run: |
-    #     curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-macos.tar.gz -L | tar xzvf -
-    #     echo "WASI_SDK_PATH=`pwd`/wasi-sdk-16.0" >> $GITHUB_ENV
-    #   if : matrix.os == 'macos-latest'
-    # - run: |
-    #     curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-mingw.tar.gz -L | tar xzvf -
-    #     echo "WASI_SDK_PATH=`pwd`/wasi-sdk-16.0" >> $GITHUB_ENV
-    #   if : matrix.os == 'windows-latest'
-
-    - name: "Install Binaryen (linux)"
-      run: |
-        set -x
-        export BINARYEN_VERSION=105
-        curl -sS -L "https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz" | tar xzf - &&
-        echo "$PWD/binaryen-version_${BINARYEN_VERSION}/bin" >> $GITHUB_PATH
-
-    # - name: "Install wasi-sdk-20 (linux)"
-    #   run: |
-    #     set -x
-    #     curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz
-    #     tar xf wasi-sdk-20.0-linux.tar.gz
-    #     sudo mkdir -p /opt/wasi-sdk
-    #     sudo mv wasi-sdk-20.0/* /opt/wasi-sdk/
+      run: rustup update stable --no-self-update |
+        rustup default 1.68.2 |
+        rustup target add wasm32-unknown-unknown |
+        rustup target add wasm32-wasi
 
     - uses: actions/setup-node@v2
       with:
         node-version: '20'
-
-    # - name: Cache wasm-tools
-    #   id: wasm-tools-cache
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: /home/runner/.cargo/bin/wasm-tools
-    #     key: crate-cache-wasm-tools
-
-    # - name: "Install wasm-tools"
-    #   if: steps.wasm-tools-cache.outputs.cache-hit != 'true'
-    #   run: cargo install wasm-tools
-
-    # - name: gecko-dev hash
-    #   id: gecko-dev-hash
-    #   run: cd deps/js-compute-runtime/runtime/spidermonkey/gecko-dev && echo "GECKO_DEV_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-    #   shell: bash
-
-    # - name: Cache Spidermonkey
-    #   uses: actions/cache@v3
-    #   id: sm-cache
-    #   with:
-    #     path: deps/js-compute-runtime/runtime/spidermonkey/release
-    #     key: cache-${{ hashFiles(
-    #         'deps/js-compute-runtime/runtime/spidermonkey/build-engine.sh',
-    #         'deps/js-compute-runtime/runtime/spidermonkey/object-files.list'
-    #       ) }}-${{ steps.gecko-dev-hash.outputs.GECKO_DEV_HASH }}
-
-    # - name: js-compute-runtime hash
-    #   id: js-compute-runtime-hash
-    #   run: cd deps/js-compute-runtime/runtime/js-compute-runtime && echo "JS_COMPUTE_RUNTIME_HASH=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-    #   shell: bash
-
-    # - name: Cache js-compute-runtime
-    #   uses: actions/cache@v3
-    #   id: js-compute-runtime
-    #   with:
-    #     path: deps/js-compute-runtime/runtime/js-compute-runtime/build
-    #     key: cache-${{ steps.js-compute-runtime-hash.outputs.GECKO_DEV_HASH }}-${{ steps.js-compute-runtime-hash.outputs.JS_COMPUTE_RUNTIME_HASH }}
 
     - name: Cache Rust dependencies
       uses: actions/cache@v3
@@ -130,7 +61,10 @@ jobs:
         key: engine-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
 
     - name: Test Example
-      run: cd example && npm run build && ./test.sh
+      run: |
+        rustup default stable |
+        rustup target add wasm32-unknown-unknown |
+        cd example && npm run build && ./test.sh |
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,12 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install Rust
+    - name: Install Rust 1.68.2, 1.76.0
       run: |
-        rustup update stable --no-self-update
-        rustup default 1.68.2
-        rustup target add wasm32-unknown-unknown
-        rustup target add wasm32-wasi
+        rustup toolchain install 1.68.2
+        rustup toolchain install 1.76.0
+        rustup target add wasm32-unknown-unknown --toolchain 1.76.0
+        rustup target add wasm32-wasi --toolchain 1.68.2
 
     - uses: actions/setup-node@v2
       with:
@@ -69,10 +69,7 @@ jobs:
         key: engine-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
 
     - name: Test Example
-      run: |
-        rustup default stable
-        rustup target add wasm32-unknown-unknown
-        cd example && npm run build && ./test.sh
+      run: cd example && npm run build && ./test.sh
 
   rustfmt:
     name: Rustfmt

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ target/
 /shared
 example/package-lock.json
 example/hello.component.wasm
-/build
+/build-debug
+/build-release
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target/
 /shared
 example/package-lock.json
 example/hello.component.wasm
+/build
+.vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "StarlingMonkey"]
 	path = StarlingMonkey
-	url = git@github.com:fermyon/StarlingMonkey
+	url = git@github.com:guybedford/StarlingMonkey

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
-[submodule "deps/js-compute-runtime"]
-	path = deps/js-compute-runtime
-	url = https://github.com/fastly/js-compute-runtime
-	shallow = true
+[submodule "StarlingMonkey"]
+	path = StarlingMonkey
+	url = git@github.com:fermyon/StarlingMonkey

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,3 @@ include("StarlingMonkey/cmake/add_as_subproject.cmake")
 add_builtin(componentize::embedding SRC embedding/embedding.cpp)
 
 project(ComponentizeJS)
-
-# if (CMAKE_BUILD_TYPE STREQUAL "Release")
-#   add_custom_command(
-#           TARGET starling.wasm
-#           POST_BUILD
-#           COMMAND ${WASM_OPT} --strip-debug -O3 -o starling.wasm starling.wasm
-#           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-#   )
-# else()
-#   add_definitions(-DDEBUG_LOGGING)
-# endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.27)
+
+include("StarlingMonkey/cmake/add_as_subproject.cmake")
+
+add_builtin(componentize::embedding SRC embedding/embedding.cpp)
+
+project(ComponentizeJS)
+
+# if (CMAKE_BUILD_TYPE STREQUAL "Release")
+#   add_custom_command(
+#           TARGET starling.wasm
+#           POST_BUILD
+#           COMMAND ${WASM_OPT} --strip-debug -O3 -o starling.wasm starling.wasm
+#           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+#   )
+# else()
+#   add_definitions(-DDEBUG_LOGGING)
+# endif()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 members = ["crates/spidermonkey-embedding-splicer"]
 exclude = [
   "deps/js-compute-runtime/runtime/js-compute-runtime/rust-url",
-  "deps/js-compute-runtime/runtime/js-compute-runtime/rust-encoding"
+  "deps/js-compute-runtime/runtime/js-compute-runtime/rust-encoding",
+  "StarlingMonkey/crates/rust-encoding",
+  "StarlingMonkey/crates/rust-url"
 ]
 resolver = "2"
 

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,31 @@
-WASM_OPT ?= $(shell rm node_modules/.bin/wasm-opt ; which wasm-opt)
+# WASM_OPT ?= $(shell rm node_modules/.bin/wasm-opt ; which wasm-opt)
 JCO ?= ./node_modules/.bin/jco
 
 ifndef JCO
 	JCO = $(error No jco in PATH. Run npm install -g @bytecodealliance/jco)
 endif
 
-ifndef WASM_OPT
-	WASM_OPT = $(error No Binaryen wasm-opt in PATH)
-endif
+# ifndef WASM_OPT
+#   WASM_OPT = $(error No Binaryen wasm-opt in PATH)
+# endif
 
 all: release
 debug: lib/starlingmonkey_embedding.debug.wasm lib/spidermonkey-embedding-splicer.js
 release: lib/starlingmonkey_embedding.wasm lib/spidermonkey-embedding-splicer.js
 
-lib/spidermonkey-embedding-splicer.js: target/wasm32-wasi/release/spidermonkey_embedding_splicer.wasm crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit | obj
+lib/spidermonkey-embedding-splicer.js: target/wasm32-wasi/release/spidermonkey_embedding_splicer.wasm crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit | obj lib
 	@$(JCO) new target/wasm32-wasi/release/spidermonkey_embedding_splicer.wasm -o obj/spidermonkey-embedding-splicer.wasm --wasi-reactor
 	@$(JCO) transpile -q --name spidermonkey-embedding-splicer obj/spidermonkey-embedding-splicer.wasm -o lib -- -O1
 
 target/wasm32-wasi/release/spidermonkey_embedding_splicer.wasm: crates/spidermonkey-embedding-splicer/Cargo.toml crates/spidermonkey-embedding-splicer/src/*.rs
 	cargo build --release --target wasm32-wasi
 
-lib/starlingmonkey_embedding.wasm: StarlingMonkey/cmake/* embedding/* StarlingMonkey/runtime/* StarlingMonkey/builtins/* StarlingMonkey/builtins/**/* StarlingMonkey/include/*
+lib/starlingmonkey_embedding.wasm: StarlingMonkey/cmake/* embedding/* StarlingMonkey/runtime/* StarlingMonkey/builtins/* StarlingMonkey/builtins/**/* StarlingMonkey/include/* | lib
 	cmake -B build-release -DCMAKE_BUILD_TYPE=Release
 	make -j16 -C build-release
 	@cp build-release/starling.wasm/starling.wasm $@
 
-lib/starlingmonkey_embedding.debug.wasm: StarlingMonkey/cmake/* embedding/* StarlingMonkey/runtime/* StarlingMonkey/builtins/* StarlingMonkey/builtins/**/* StarlingMonkey/include/*
+lib/starlingmonkey_embedding.debug.wasm: StarlingMonkey/cmake/* embedding/* StarlingMonkey/runtime/* StarlingMonkey/builtins/* StarlingMonkey/builtins/**/* StarlingMonkey/include/* | lib
 	cmake -B build-debug -DCMAKE_BUILD_TYPE=RelWithDebInfo
 	make -j16 -C build-debug
 	@cp build-debug/starling.wasm/starling.wasm $@

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,5 @@
-WASI_SDK ?= /opt/wasi-sdk
-WASI_CXX ?= $(WASI_SDK)/bin/clang++
-WASI_CC ?= $(WASI_SDK)/bin/clang
-WASM_TOOLS ?= $(shell which wasm-tools)
 WASM_OPT ?= $(shell rm node_modules/.bin/wasm-opt ; which wasm-opt)
 JCO ?= ./node_modules/.bin/jco
-WIT_BINDGEN := $(shell which wit-bindgen)
-
-ifndef WIT_BINDGEN
-	WIT_BINDGEN = $(error No wit-bindgen in PATH, consider doing cargo install --git https://github.com/bytecodealliance/wit-bindgen wit-bindgen-cli)
-endif
 
 ifndef JCO
 	JCO = $(error No jco in PATH. Run npm install -g @bytecodealliance/jco)
@@ -18,58 +9,28 @@ ifndef WASM_OPT
 	WASM_OPT = $(error No Binaryen wasm-opt in PATH)
 endif
 
-ifndef WASM_TOOLS
-	WASM_TOOLS = $(error No wasm-tools in PATH. First run "cargo install wasm-tools")
-endif
-
-SM_SRC := deps/js-compute-runtime/runtime/spidermonkey/release
-JSCR_SRC := deps/js-compute-runtime/runtime/js-compute-runtime
-
-CXX_FLAGS := -std=gnu++20 -Wall -Werror -Qunused-arguments
-CXX_FLAGS += -fno-sized-deallocation -fno-aligned-new -mthread-model single
-CXX_FLAGS += -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe
-CXX_FLAGS += -fno-omit-frame-pointer -funwind-tables -I$(SM_SRC/include)
-CXX_FLAGS += --sysroot=$(WASI_SDK)/share/wasi-sysroot# -DDEBUG
-
-CXX_OPT ?= -O2
-
-CFLAGS := -Wall -Werror -Wno-unknown-attributes -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
-
-LD_FLAGS := -Wl,-z,stack-size=1048576 -Wl,--stack-first -lwasi-emulated-getpid# -Wl,--export-table
-
-DEFINES ?= 
-
-INCLUDES := -I $(JSCR_SRC)
-
-OBJS := $(patsubst spidermonkey_embedding/%.cpp,obj/%.o,$(wildcard spidermonkey_embedding/**/*.cpp)) $(patsubst spidermonkey_embedding/%.cpp,obj/%.o,$(wildcard spidermonkey_embedding/*.cpp))
-
-all: lib/spidermonkey-embedding-splicer.js lib/spidermonkey_embedding.wasm
+all: lib/spidermonkey-embedding-splicer.js lib/starlingmonkey_embedding.debug.wasm
 
 lib/spidermonkey-embedding-splicer.js: target/wasm32-wasi/release/spidermonkey_embedding_splicer.wasm crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit | obj
 	$(JCO) new target/wasm32-wasi/release/spidermonkey_embedding_splicer.wasm -o obj/spidermonkey-embedding-splicer.wasm --wasi-reactor
 	$(JCO) transpile -q --name spidermonkey-embedding-splicer obj/spidermonkey-embedding-splicer.wasm -o lib -- -O1
 
-target/wasm32-wasi/release/spidermonkey_embedding_splicer.wasm: crates/spidermonkey-embedding-splicer/Cargo.toml crates/spidermonkey-embedding-splicer/src/lib.rs
+target/wasm32-wasi/release/spidermonkey_embedding_splicer.wasm: crates/spidermonkey-embedding-splicer/Cargo.toml crates/spidermonkey-embedding-splicer/src/*.rs
 	cargo build --release --target wasm32-wasi
 
-lib/spidermonkey_embedding.wasm: $(OBJS) | $(SM_SRC)
-	-make --makefile=$(JSCR_SRC)/Makefile -I $(JSCR_SRC) $(abspath $(JSCR_SRC)/js-compute-runtime.wasm) $(abspath $(JSCR_SRC)/js-compute-runtime-component.wasm) -j16
-	make --makefile=$(JSCR_SRC)/Makefile -I $(JSCR_SRC) -j16
-	make --makefile=$(JSCR_SRC)/Makefile -I $(JSCR_SRC) $(abspath $(JSCR_SRC)/build/release/shared.a) -j16
-	PATH="$(FSM_SRC)/scripts:$$PATH" $(WASI_CXX) $(CXX_FLAGS) $(CXX_OPT) $(DEFINES) $(LD_FLAGS) -o $@ $^ deps/js-compute-runtime/runtime/js-compute-runtime/build/release/*.a $(wildcard $(SM_SRC)/lib/*.a) $(wildcard $(SM_SRC)/lib/*.o)
-	$(WASM_OPT) --strip-debug $@ -o $@ -O3
+lib/starlingmonkey_embedding.debug.wasm: $(wildcard embedding/*) $(wildcard StarlingMonkey/runtime/*) $(wildcard StarlingMonkey/builtins/*) $(wildcard StarlingMonkey/builtins/**/*) $(wildcard StarlingMonkey/include/*)
+	cmake -B build -DCMAKE_BUILD_TYPE=Release
+	make -j16 -C build
+	@cp build/starling.wasm/starling.wasm $@
 
-obj/%.o: spidermonkey_embedding/%.cpp Makefile | $(SM_SRC) obj obj/builtins
-	$(WASI_CXX) $(CXX_FLAGS) -O2 $(DEFINES) $(INCLUDES) -I $(SM_SRC)/include -MMD -MP -c -o $@ $<
+lib/starlingmonkey_embedding.wasm: lib/starlingmonkey_embedding.debug.wasm
+	$(WASM_OPT) --strip-debug lib/starlingmonkey_embedding.debug.wasm -o $@ -O3
 
 obj:
 	mkdir -p obj
 
 lib:
 	mkdir -p lib
-
-$(SM_SRC):
-	cd deps/js-compute-runtime/runtime/spidermonkey && ./build-engine.sh release
 
 obj/builtins:
 	mkdir -p obj/builtins

--- a/crates/spidermonkey-embedding-splicer/src/bindgen.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bindgen.rs
@@ -334,7 +334,7 @@ pub fn componentize_bindgen(resolve: &Resolve, id: WorldId, name: &str) -> Compo
                     .map(|name| format!(", $resource_{name}"))
             )
             .collect::<Vec<_>>()
-            .concat()
+            .concat(),
     );
 
     bindgen.esm_bindgen.render_export_imports(

--- a/crates/spidermonkey-embedding-splicer/src/bindgen.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bindgen.rs
@@ -214,7 +214,10 @@ pub fn componentize_bindgen(resolve: &Resolve, id: WorldId, name: &str) -> Compo
         let joined_bindings = specifier_list.join(", ");
         import_wrappers.push((
             specifier.to_string(),
-            format!("export {{ {joined_bindings} }} from 'internal:bindings';"),
+            format!(
+                "export {{ {joined_bindings} }} from './{}.bindings.js';",
+                &name[0..name.len() - 3]
+            ),
         ));
     }
 
@@ -317,11 +320,8 @@ pub fn componentize_bindgen(resolve: &Resolve, id: WorldId, name: &str) -> Compo
 
             Symbol.dispose = Symbol.for('dispose');
 
-            let $memory, $realloc{};
-            export function $initBindings (_memory, _realloc{}) {{
-                $memory = _memory;
-                $realloc = _realloc;{}
-            }}
+            let [$memory, $realloc{}] = $bindings;
+            delete globalThis.$bindings;
 
             {finalization_registries}
         ",
@@ -334,23 +334,7 @@ pub fn componentize_bindgen(resolve: &Resolve, id: WorldId, name: &str) -> Compo
                     .map(|name| format!(", $resource_{name}"))
             )
             .collect::<Vec<_>>()
-            .concat(),
-        import_bindings
-            .iter()
-            .chain(&resource_bindings)
-            .map(|impt| format!(", _{impt}"))
-            .collect::<Vec<_>>()
-            .concat(),
-        import_bindings
-            .iter()
-            .map(|impt| format!("\n$import_{impt} = _{impt};"))
-            .chain(
-                resource_bindings
-                    .iter()
-                    .map(|name| format!("\n$resource_{name} = _{name}"))
-            )
-            .collect::<Vec<_>>()
-            .concat(),
+            .concat()
     );
 
     bindgen.esm_bindgen.render_export_imports(

--- a/crates/spidermonkey-embedding-splicer/src/lib.rs
+++ b/crates/spidermonkey-embedding-splicer/src/lib.rs
@@ -157,6 +157,7 @@ impl Guest for SpidermonkeyEmbeddingSplicerComponent {
                     engine_resolve.name_world_key(key) == "wasi:http/incoming-handler@0.2.0"
                 })
                 .map(|(key, _)| key.clone());
+
             if let Some(serve) = maybe_serve {
                 engine_resolve.worlds[engine_world]
                     .exports

--- a/crates/spidermonkey-embedding-splicer/src/splice.rs
+++ b/crates/spidermonkey-embedding-splicer/src/splice.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use walrus::{
     ir::{
         BinaryOp, Binop, Const, Instr, LoadKind, LocalGet, LocalSet, LocalTee, MemArg, Store,

--- a/crates/spidermonkey-embedding-splicer/src/splice.rs
+++ b/crates/spidermonkey-embedding-splicer/src/splice.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use walrus::{
-    ir::{BinaryOp, Binop, Const, LoadKind, MemArg, Store, StoreKind, UnaryOp, Unop, Value},
-    ir::{Instr, LocalGet, LocalSet, LocalTee},
+    ir::{
+        BinaryOp, Binop, Const, Instr, LoadKind, LocalGet, LocalSet, LocalTee, MemArg, Store,
+        StoreKind, UnaryOp, Unop, Value,
+    },
     ExportId, ExportItem, FunctionBuilder, FunctionId, LocalId, ValType,
 };
 
@@ -38,6 +40,34 @@ pub fn splice(
 ) -> Result<Vec<u8>> {
     let config = walrus::ModuleConfig::new();
     let mut module = config.parse(&engine)?;
+
+    // since StarlingMonkey implements CLI Run and incoming handler,
+    // we override these in ComponentizeJS, removing them from the
+    // core function exports
+    if let Ok(run) = module.exports.get_func("wasi:cli/run@0.2.0#run") {
+        let expt = module.exports.get_exported_func(run).unwrap();
+        module.exports.delete(expt.id());
+        module.funcs.delete(run);
+    }
+    if let Ok(serve) = module
+        .exports
+        .get_func("wasi:http/incoming-handler@0.2.0#handle")
+    {
+        let expt = module.exports.get_exported_func(serve).unwrap();
+        module.exports.delete(expt.id());
+        module.funcs.delete(serve);
+    }
+
+    // we reencode the WASI world component data, so strip it out from the
+    // custom section
+    let maybe_component_section_id = module
+        .customs
+        .iter()
+        .find(|(_, section)| section.name() == "component-type:bindings")
+        .map(|(id, _)| id);
+    if let Some(component_section_id) = maybe_component_section_id {
+        module.customs.delete(component_section_id);
+    }
 
     // extract the native instructions from sample functions
     // then inline the imported functions and main import gating function
@@ -174,8 +204,15 @@ fn synthesize_import_functions(
                 None => vec![],
             };
             let import_fn_type = module.types.add(&params, &ret);
-            let (import_fn_fid, _) =
-                module.add_import_func(&impt_specifier, &impt_name, import_fn_type);
+
+            let import_fn_fid =
+                if let Ok(existing) = module.imports.get_func(&impt_specifier, &impt_name) {
+                    existing
+                } else {
+                    module
+                        .add_import_func(&impt_specifier, &impt_name, import_fn_type)
+                        .0
+                };
 
             // create the native JS binding function
             let mut func = FunctionBuilder::new(
@@ -481,7 +518,7 @@ fn synthesize_import_functions(
     module.exports.delete(coreabi_from_bigint64);
     module.exports.delete(coreabi_get_import.unwrap());
     for id in coreabi_sample_ids {
-        module.exports.delete(id); // 3394
+        module.exports.delete(id);
     }
 
     Ok(())

--- a/embedding/embedding.cpp
+++ b/embedding/embedding.cpp
@@ -261,7 +261,7 @@ extern "C"
 
   __attribute__((export_name("post_call"))) void post_call(uint32_t fn_idx)
   {
-    LOG("(post_call) Function [%d]\n", fn_idx);
+    LOG("(post_call) Function [%d]", fn_idx);
     if (Runtime.cur_fn_idx != fn_idx)
     {
       LOG("(post_call) Unexpected call state, post_call must only be called immediately after call");
@@ -418,7 +418,7 @@ namespace componentize::embedding
 
   void cabi_free(void *ptr)
   {
-    LOG("(cabi_free) %d\n", (uint32_t)ptr);
+    LOG("(cabi_free) %d", (uint32_t)ptr);
     JS_free(Runtime.cx, ptr);
   }
 
@@ -465,7 +465,13 @@ namespace componentize::embedding
     if (sbrk(0) != LAST_SBRK)
     {
       LAST_SBRK = sbrk(0);
-      AB = JS::RootedObject(Runtime.cx, JS::NewArrayBufferWithUserOwnedContents(Runtime.cx, (size_t)LAST_SBRK, (void *)0));
+      #ifdef DEBUG
+        void* base = (void*)64;
+      #else
+        void* base = 0;
+      #endif
+      JS::RootedObject mem_buffer(cx, JS::NewArrayBufferWithUserOwnedContents(cx, (size_t)LAST_SBRK, base));
+      AB.init(cx, mem_buffer);
     }
     JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
     args.rval().setObject(*AB);
@@ -505,7 +511,7 @@ namespace componentize::embedding
     JS::RootedObject function_obj(Runtime.cx, JS_GetFunctionObject(realloc_fn));
     JS_SetElement(Runtime.cx, import_bindings, 1, function_obj);
 
-    LOG("(wizer) create the import JS functions");
+    LOG("(wizer) create the %d import JS functions", import_cnt);
     for (size_t i = 0; i < import_cnt; i++)
     {
       sprintf(&env_name[0], "IMPORT%zu_NAME", i);

--- a/embedding/embedding.cpp
+++ b/embedding/embedding.cpp
@@ -1,0 +1,535 @@
+#include "embedding.h"
+
+namespace builtins::web::console {
+
+class Console : public BuiltinNoConstructor<Console> {
+private:
+public:
+  static constexpr const char *class_name = "Console";
+  enum LogType {
+    Log,
+    Info,
+    Debug,
+    Warn,
+    Error,
+  };
+  enum Slots { Count };
+  static const JSFunctionSpec methods[];
+  static const JSPropertySpec properties[];
+};
+
+void builtin_impl_console_log(Console::LogType log_ty, const char *msg) {
+  fprintf(stdout, "%s\n", msg);
+  fflush(stdout);
+}
+
+} // builtins::web::console
+
+extern "C"
+{ 
+  using componentize::embedding::Runtime;
+  using componentize::embedding::cabi_free;
+  using componentize::embedding::ReportAndClearException;
+  using componentize::embedding::ComponentizeRuntime;
+  using componentize::embedding::CoreVal;
+
+  // These functions are used both internally and also exported for use directly by the splicer codegen
+  __attribute__((noinline, export_name("coreabi_from_bigint64"))) int64_t from_bigint64(JS::MutableHandleValue handle)
+  {
+    JS::BigInt *arg0 = handle.toBigInt();
+    uint64_t arg0_uint64;
+    if (!JS::detail::BigIntIsUint64(arg0, &arg0_uint64))
+    {
+      abort();
+    }
+    return arg0_uint64;
+  }
+
+  __attribute__((noinline, export_name("coreabi_to_bigint64"))) JS::BigInt *to_bigint64(JSContext *cx, int64_t val)
+  {
+    return JS::detail::BigIntFromUint64(cx, val);
+  }
+
+  /*
+   * These 4 "sample" functions are deconstructed after compilation and fully
+   * removed. The prime number separates the get from the set in this deconstruction.
+   * The generated code is then used to build a template for constructing
+   * the generic binding functions from it. By always keeping these samples around we
+   * can ensure this approach is resiliant to some degree of compiled output changes,
+   * or at least throw a vaguely useful error when that is no longer the case.
+   */
+  __attribute__((export_name("coreabi_sample_i32"))) bool CoreAbiSampleI32(JSContext *cx, unsigned argc, JS::Value *vp)
+  {
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    int32_t arg0 = static_cast<int32_t>(args[0].toInt32());
+    args.rval().setInt32(arg0 * 32771);
+    return true;
+  }
+
+  __attribute__((export_name("coreabi_sample_i64"))) bool CoreAbiSampleI64(JSContext *cx, unsigned argc, JS::Value *vp)
+  {
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    int64_t arg1 = from_bigint64(args[1]);
+    args.rval().setBigInt(to_bigint64(cx, arg1));
+    return true;
+  }
+
+  __attribute__((export_name("coreabi_sample_f32"))) bool CoreAbiSampleF32(JSContext *cx, unsigned argc, JS::Value *vp)
+  {
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    float arg2 = static_cast<float>(args[2].toDouble());
+    args.rval().setDouble(arg2);
+    return true;
+  }
+
+  __attribute__((export_name("coreabi_sample_f64"))) bool CoreAbiSampleF64(JSContext *cx, unsigned argc, JS::Value *vp)
+  {
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    double arg3 = args[3].toDouble();
+    args.rval().setDouble(arg3);
+    return true;
+  }
+
+  // Allocation functions for the splicer
+  __attribute__((optnone, export_name("coreabi_get_import")))
+  JSFunction *
+  coreabi_get_import(int32_t idx, int32_t argcnt, const char *name)
+  {
+    return JS_NewFunction(Runtime.cx, CoreAbiSampleI32, argcnt, 0, name);
+  }
+
+  __attribute__((export_name("cabi_realloc_adapter"))) void *cabi_realloc_adapter(void *ptr, size_t orig_size, size_t org_align, size_t new_size)
+  {
+    return JS_realloc(Runtime.cx, ptr, orig_size, new_size);
+  }
+
+  // This MUST override the StarlingMonkey core cabi_realloc export
+  __attribute__((export_name("cabi_realloc"))) void *cabi_realloc(void *ptr, size_t orig_size, size_t org_align, size_t new_size)
+  {
+    void *ret = JS_realloc(Runtime.cx, ptr, orig_size, new_size);
+    // track all allocations during a function "call" for freeing
+    Runtime.free_list.push_back(ret);
+    if (!ret)
+    {
+      LOG("(cabi_realloc) Unable to realloc");
+      abort();
+    }
+    LOG("(cabi_realloc) [%d %zu %zu] %d\n", (uint32_t)ptr, orig_size, new_size, (uint32_t)ret);
+    return ret;
+  }
+
+  __attribute__((export_name("call"))) uint32_t call(uint32_t fn_idx, void *argptr)
+  {
+    if (Runtime.first_call)
+    {
+      js::ResetMathRandomSeed(Runtime.cx);
+      Runtime.first_call = false;
+    }
+    if (Runtime.cur_fn_idx != -1)
+    {
+      LOG("(call) unexpected call state, post_call was not called after last call");
+      abort();
+    }
+    Runtime.cur_fn_idx = fn_idx;
+    ComponentizeRuntime::CoreFn *fn = &Runtime.fns[fn_idx];
+    if (Runtime.debug)
+    {
+      fprintf(stderr, "(call) Function [%d] - ", fn_idx);
+      fprintf(stderr, "(");
+      if (fn->paramptr)
+      {
+        fprintf(stderr, "*");
+      }
+      bool first = true;
+      for (int i = 0; i < fn->args.size(); i++)
+      {
+        if (first)
+        {
+          first = false;
+        }
+        else
+        {
+          fprintf(stderr, ", ");
+        }
+        fprintf(stderr, "%s", core_ty_str(fn->args[i]));
+      }
+      fprintf(stderr, ")");
+      if (fn->ret.has_value())
+      {
+        fprintf(stderr, " -> ");
+        if (fn->retptr)
+        {
+          fprintf(stderr, "*");
+        }
+        fprintf(stderr, "%s", core_ty_str(fn->ret.value()));
+      }
+      fprintf(stderr, "\n");
+    }
+
+    JSAutoRealm ar(Runtime.cx, Runtime.engine->global());
+
+    JS::RootedVector<JS::Value> args(Runtime.cx);
+    if (!args.resize(fn->args.size() + (fn->retptr ? 1 : 0)))
+    {
+      LOG("(call) unable to allocate memory for array resize");
+      abort();
+    }
+
+    LOG("(call) setting args");
+    int argcnt = 0;
+    if (fn->paramptr)
+    {
+      args[0].setInt32((uint32_t)argptr);
+      argcnt = 1;
+    }
+    else if (fn->args.size() > 0)
+    {
+      uint32_t *curptr = static_cast<uint32_t *>(argptr);
+      argcnt = fn->args.size();
+      for (int i = 0; i < argcnt; i++)
+      {
+        switch (fn->args[i])
+        {
+        case CoreVal::I32:
+          args[i].setInt32(*curptr);
+          curptr += 1;
+          break;
+        case CoreVal::I64:
+          args[i].setBigInt(JS::detail::BigIntFromUint64(Runtime.cx, *(uint64_t *)(curptr)));
+          curptr += 2;
+          break;
+        case CoreVal::F32:
+          args[i].setNumber(*((float *)curptr));
+          curptr += 1;
+          break;
+        case CoreVal::F64:
+          args[i].setNumber(*((double *)curptr));
+          curptr += 2;
+          break;
+        }
+      }
+    }
+
+    void *retptr = nullptr;
+    if (fn->retptr)
+    {
+      LOG("(call) setting retptr at arg %d\n", argcnt);
+      retptr = JS_realloc(Runtime.cx, 0, 0, fn->retsize);
+      args[argcnt].setInt32((uint32_t)retptr);
+    }
+
+    LOG("(call) JS lowering call");
+    JS::RootedValue r(Runtime.cx);
+    if (!JS_CallFunctionValue(Runtime.cx, nullptr, fn->func, args, &r))
+    {
+      LOG("(call) runtime JS Error");
+      ReportAndClearException(Runtime.cx);
+      abort();
+    }
+
+    // Handle singular returns
+    if (!fn->retptr && fn->ret.has_value())
+    {
+      LOG("(call) singular return");
+      retptr = cabi_realloc(0, 0, 4, fn->retsize);
+      switch (fn->ret.value())
+      {
+      case CoreVal::I32:
+        *((uint32_t *)retptr) = r.toInt32();
+        break;
+      case CoreVal::I64:
+        if (!JS::detail::BigIntIsUint64(r.toBigInt(), (uint64_t *)retptr))
+        {
+          abort();
+        }
+        break;
+      case CoreVal::F32:
+        *((float *)retptr) = r.isInt32() ? static_cast<float>(r.toInt32()) : static_cast<float>(r.toDouble());
+        break;
+      case CoreVal::F64:
+        *((double *)retptr) = r.isInt32() ? static_cast<double>(r.toInt32()) : r.toDouble();
+        break;
+      }
+    }
+
+    LOG("(call) end");
+
+    // we always return a retptr (even if null)
+    // the wrapper will drop it if not needed
+    return (uint32_t)retptr;
+  }
+
+  __attribute__((export_name("post_call"))) void post_call(uint32_t fn_idx)
+  {
+    LOG("(post_call) Function [%d]\n", fn_idx);
+    if (Runtime.cur_fn_idx != fn_idx)
+    {
+      LOG("(post_call) Unexpected call state, post_call must only be called immediately after call");
+      abort();
+    }
+    Runtime.cur_fn_idx = -1;
+    for (void *ptr : Runtime.free_list)
+    {
+      cabi_free(ptr);
+    }
+    Runtime.free_list.clear();
+    js::RunJobs(Runtime.cx);
+    JS_MaybeGC(Runtime.cx);
+    LOG("(post_call) end");
+  }
+
+  __attribute__((export_name("check_init"))) ComponentizeRuntime::InitError check_init() {
+    JSAutoRealm ar(Runtime.cx, Runtime.engine->global());
+    JS::RootedValue exc(Runtime.cx);
+    if (JS_GetPendingException(Runtime.cx, &exc))
+    {
+      ReportAndClearException(Runtime.cx);
+    }
+    return Runtime.init_err;
+  }
+
+  __attribute__((export_name("componentize.wizer")))
+  void componentize_initialize() {
+    uint32_t is_debug = atoi(getenv("DEBUG"));
+    if (is_debug)
+    {
+      Runtime.debug = true;
+    }
+
+    __wizer_initialize();
+    char env_name[100];
+    LOG("(wizer) retrieve and generate the export bindings");
+    RootedObject ns(Runtime.cx, &Runtime.engine->script_value().toObject());
+
+    uint32_t export_cnt = atoi(getenv("EXPORT_CNT"));
+    for (size_t i = 0; i < export_cnt; i++)
+    {
+      ComponentizeRuntime::CoreFn *fn = &Runtime.fns.emplace_back();
+
+      sprintf(&env_name[0], "EXPORT%zu_NAME", i);
+      RootedValue function_binding(Runtime.cx);
+      if (!JS_GetProperty(Runtime.cx, ns, getenv(env_name), &function_binding))
+      {
+        Runtime.init_err = ComponentizeRuntime::InitError::FnList;
+        return;
+      }
+
+      fn->func.init(Runtime.cx, function_binding);
+
+      // rudimentary data marshalling to parse the core ABI
+      // export type from the env vars
+      sprintf(&env_name[0], "EXPORT%zu_ARGS", i);
+      char *arg_tys = getenv(env_name);
+      int j = 0;
+      char ch;
+      if (arg_tys[0] == '*')
+      {
+        fn->paramptr = true;
+        j++;
+      }
+      while (true)
+      {
+        ch = arg_tys[j];
+        if (ch == '\0')
+          break;
+        if (strncmp(&arg_tys[j], "i32", 3) == 0)
+        {
+          fn->args.push_back(CoreVal::I32);
+          j += 3;
+        }
+        else if (strncmp(&arg_tys[j], "i64", 3) == 0)
+        {
+          fn->args.push_back(CoreVal::I64);
+          j += 3;
+        }
+        else if (strncmp(&arg_tys[j], "f32", 3) == 0)
+        {
+          fn->args.push_back(CoreVal::F32);
+          j += 3;
+        }
+        else if (strncmp(&arg_tys[j], "f64", 3) == 0)
+        {
+          fn->args.push_back(CoreVal::F64);
+          j += 3;
+        }
+        else
+        {
+          Runtime.init_err = ComponentizeRuntime::InitError::TypeParse;
+          return;
+        }
+        if (arg_tys[j] == ',')
+        {
+          j++;
+        }
+      }
+
+      sprintf(&env_name[0], "EXPORT%zu_RET", i);
+      arg_tys = getenv(env_name);
+      j = 0;
+      if (arg_tys[0] != '\0')
+      {
+        if (arg_tys[0] == '*')
+        {
+          fn->retptr = true;
+          j++;
+        }
+        if (strncmp(&arg_tys[j], "i32", 3) == 0)
+        {
+          fn->ret.emplace(CoreVal::I32);
+        }
+        else if (strncmp(&arg_tys[j], "i64", 3) == 0)
+        {
+          fn->ret.emplace(CoreVal::I64);
+        }
+        else if (strncmp(&arg_tys[j], "f32", 3) == 0)
+        {
+          fn->ret.emplace(CoreVal::F32);
+        }
+        else if (strncmp(&arg_tys[j], "f64", 3) == 0)
+        {
+          fn->ret.emplace(CoreVal::F64);
+        }
+        else
+        {
+          Runtime.init_err = ComponentizeRuntime::InitError::TypeParse;
+          return;
+        }
+      }
+
+      sprintf(&env_name[0], "EXPORT%zu_RETSIZE", i);
+      fn->retsize = atoi(getenv(env_name));
+    }
+  }
+}
+
+namespace componentize::embedding
+{
+  static bool ReallocFn(JSContext *cx, unsigned argc, JS::Value *vp)
+  {
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    void *old_ptr = (void *)args[0].toInt32();
+    size_t old_len = args[1].toInt32();
+    size_t align = args[2].toInt32();
+    size_t new_len = args[3].toInt32();
+    void *ptr = cabi_realloc(old_ptr, old_len, align, new_len);
+    args.rval().setInt32((uint32_t)ptr);
+    return true;
+  }
+
+  void cabi_free(void *ptr)
+  {
+    LOG("(cabi_free) %d\n", (uint32_t)ptr);
+    JS_free(Runtime.cx, ptr);
+  }
+
+  const char *core_ty_str(CoreVal ty)
+  {
+    switch (ty)
+    {
+    case CoreVal::I32:
+      return "i32";
+    case CoreVal::I64:
+      return "i64";
+    case CoreVal::F32:
+      return "f32";
+    case CoreVal::F64:
+      return "f64";
+    }
+  }
+
+  // Note requires an AutoRealm
+  bool ReportAndClearException(JSContext *cx)
+  {
+    JS::ExceptionStack stack(cx);
+    if (!JS::StealPendingExceptionStack(cx, &stack))
+    {
+      LOG("(err) Uncatchable exception thrown");
+      return false;
+    }
+
+    JS::ErrorReportBuilder report(cx);
+    if (!report.init(cx, stack, JS::ErrorReportBuilder::WithSideEffects))
+    {
+      LOG("(err) Couldn't build error report");
+      return false;
+    }
+
+    JS::PrintError(stderr, report, false);
+    return true;
+  }
+
+  void *LAST_SBRK;
+  JS::PersistentRootedObject AB;
+  static bool GetMemBuffer(JSContext *cx, unsigned argc, JS::Value *vp)
+  {
+    if (sbrk(0) != LAST_SBRK)
+    {
+      LAST_SBRK = sbrk(0);
+      AB = JS::RootedObject(Runtime.cx, JS::NewArrayBufferWithUserOwnedContents(Runtime.cx, (size_t)LAST_SBRK, (void *)0));
+    }
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    args.rval().setObject(*AB);
+    return true;
+  }
+
+  bool install(api::Engine *engine)
+  {
+    Runtime.engine = engine;
+    Runtime.cx = engine->cx();
+
+    char env_name[100];
+
+    Runtime.source_name = std::string(getenv("SOURCE_NAME"));
+
+    // -- Wire up the imports  --
+    uint32_t import_cnt = atoi(getenv("IMPORT_CNT"));
+
+    JS::RootedObject import_bindings(Runtime.cx, JS::NewArrayObject(Runtime.cx, 2 + import_cnt));
+
+    LOG("(wizer) create the memory buffer JS object");
+    JS::RootedObject mem(Runtime.cx, JS_NewPlainObject(Runtime.cx));
+    if (!JS_DefineProperty(Runtime.cx, mem, "buffer", GetMemBuffer,
+                          nullptr, JSPROP_ENUMERATE))
+    {
+      return false;
+    }
+
+    JS_SetElement(Runtime.cx, import_bindings, 0, mem);
+
+    LOG("(wizer) create the realloc JS function");
+    JSFunction *realloc_fn = JS_NewFunction(Runtime.cx, ReallocFn, 0, 0, "realloc");
+    if (!realloc_fn)
+    {
+      return false;
+    }
+    JS::RootedObject function_obj(Runtime.cx, JS_GetFunctionObject(realloc_fn));
+    JS_SetElement(Runtime.cx, import_bindings, 1, function_obj);
+
+    LOG("(wizer) create the import JS functions");
+    for (size_t i = 0; i < import_cnt; i++)
+    {
+      sprintf(&env_name[0], "IMPORT%zu_NAME", i);
+      const char *name = getenv(env_name);
+      sprintf(&env_name[0], "IMPORT%zu_ARGCNT", i);
+      uint32_t argcnt = atoi(getenv(env_name));
+
+      JSFunction *import_fn = coreabi_get_import(i, argcnt, name);
+      if (!import_fn)
+      {
+        return false;
+      }
+      JS::RootedObject function_obj(Runtime.cx, JS_GetFunctionObject(import_fn));
+      JS_SetElement(Runtime.cx, import_bindings, 2 + i, function_obj);
+    }
+
+    LOG("(wizer) setting the binding global");
+    if (!JS_DefineProperty(engine->cx(), engine->global(), "$bindings", import_bindings, 0)) {
+      return false;
+    }
+
+    LOG("(wizer) complete");
+    
+    return true;
+  }
+
+} // namespace componentize

--- a/embedding/embedding.h
+++ b/embedding/embedding.h
@@ -1,0 +1,124 @@
+#include "extension-api.h"
+#include <js/BigInt.h>
+#include <jsapi.h>
+#include <cstdio>
+// #include <assert.h>
+#include <unistd.h>
+#include <js/Array.h>
+
+#define LOG(...)                               \
+  if (Runtime.debug)                           \
+  {                                            \
+    fprintf(stderr, __VA_ARGS__);              \
+    fprintf(stderr, "\n");                     \
+    fflush(stdout);                            \
+  }
+
+// StarlingMonkey Wizer initialize function
+// we intercept the Wizer function to add our own
+// wrapper around this Wizer function
+void __wizer_initialize();
+
+namespace componentize::embedding
+{
+  enum class CoreVal : char
+  {
+    I32,
+    I64,
+    F32,
+    F64
+  };
+  struct ComponentizeRuntime
+  {
+    enum class InitError
+    {
+      OK,
+      JSInit,
+      Intrinsics,
+      CustomIntrinsics,
+      SourceStdin,
+      SourceCompile,
+      BindingsCompile,
+      ImportWrapperCompile,
+      SourceLink,
+      SourceExec,
+      BindingsExec,
+      // Deprecated
+      FnList,
+      MemBuffer,
+      ReallocFn,
+      // Deprecated
+      MemBindings,
+      PromiseRejections,
+      ImportFn,
+      TypeParse
+    };
+
+    enum class RuntimeError
+    {
+      OK,
+      BigInt,
+    };
+
+    bool debug = false;
+    bool first_call = true;
+
+    JSContext *cx;
+
+    InitError init_err = InitError::OK;
+    RuntimeError runtime_err = RuntimeError::OK;
+
+    // The name of the source being executed
+    std::string source_name;
+
+    // The user module being executed
+    JS::PersistentRootedObject mod;
+    // The internal generated bindings module being executed
+    JS::PersistentRootedObject mod_bindings;
+
+    api::Engine *engine;
+
+    // The core abi "lowered" functions for the user code being executed
+    struct CoreFn
+    {
+      // The compiled JS core function
+      JS::PersistentRootedValue func;
+      // The type of the function params
+      // If using a retptr, the last param will be the retptr
+      std::vector<CoreVal> args;
+      // The type of the function return
+      // Functions with more than one return value use a retptr
+      std::optional<CoreVal> ret;
+      // whether the function has a retptr
+      bool retptr = false;
+      // whether the function has a param ptr
+      bool paramptr = false;
+      // when using a retptr, the size of the ret area
+      uint32_t retsize = false;
+
+      CoreFn() : func(), args(), ret() {}
+    };
+    std::vector<CoreFn> fns;
+
+    // the current export function call
+    int cur_fn_idx = -1;
+    std::vector<void *> free_list;
+
+    void free_list_remove(void *ptr)
+    {
+      free_list.erase(std::remove(free_list.begin(), free_list.end(), ptr), free_list.end());
+    }
+
+    ComponentizeRuntime() : engine(nullptr),
+                            fns(),
+                            free_list() {}
+  };
+
+  // Runtime singleton
+  ComponentizeRuntime Runtime = ComponentizeRuntime();
+
+  void cabi_free(void *ptr);
+  const char *core_ty_str(CoreVal ty);
+  bool ReportAndClearException(JSContext *cx);
+
+} // namespace componentize

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -36,10 +36,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
+name = "android_system_properties"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "arbitrary"
@@ -70,13 +79,13 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
- "event-listener 4.0.0",
- "event-listener-strategy",
+ "event-listener 5.2.0",
+ "event-listener-strategy 0.5.0",
  "futures-core",
  "pin-project-lite",
 ]
@@ -87,26 +96,26 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock 3.1.2",
+ "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite 2.0.1",
+ "futures-lite 2.3.0",
  "slab",
 ]
 
 [[package]]
 name = "async-global-executor"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4353121d5644cdf2beb5726ab752e79a8db1ebb52031770ec47db31d245526"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.1.1",
+ "async-channel 2.2.0",
  "async-executor",
- "async-io 2.2.1",
- "async-lock 3.1.2",
+ "async-io 2.3.2",
+ "async-lock 3.3.0",
  "blocking",
- "futures-lite 2.0.1",
+ "futures-lite 2.3.0",
  "once_cell",
 ]
 
@@ -132,18 +141,18 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.2.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d3b15875ba253d1110c740755e246537483f152fa334f91abd7fe84c88b3ff"
+checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
 dependencies = [
- "async-lock 3.1.2",
+ "async-lock 3.3.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.0.1",
+ "futures-lite 2.3.0",
  "parking",
- "polling 3.3.1",
- "rustix 0.38.26",
+ "polling 3.5.0",
+ "rustix 0.38.31",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -160,12 +169,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.1.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea8b3453dd7cc96711834b75400d671b73e3656975fa68d9f277163b7f7e316"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
- "event-listener 4.0.0",
- "event-listener-strategy",
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
  "pin-project-lite",
 ]
 
@@ -198,19 +207,19 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.5.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -242,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bincode"
@@ -263,9 +272,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -282,21 +291,21 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
- "async-channel 2.1.1",
- "async-lock 3.1.2",
+ "async-channel 2.2.0",
+ "async-lock 3.3.0",
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.0.1",
+ "futures-lite 2.3.0",
  "piper",
  "tracing",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byteorder"
@@ -312,33 +321,33 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cap-fs-ext"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b779b2d0a001c125b4584ad586268fb4b92d957bff8d26d7fe0dd78283faa814"
+checksum = "88e341d15ac1029aadce600be764a1a1edafe40e03cde23285bc1d261b3a4866"
 dependencies = [
- "cap-primitives",
- "cap-std",
+ "cap-primitives 2.0.1",
+ "cap-std 2.0.1",
  "io-lifetimes 2.0.3",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "cap-net-ext"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffc30dee200c20b4dcb80572226f42658e1d9c4b668656d7cc59c33d50e396e"
+checksum = "434168fe6533055f0f4204039abe3ff6d7db338ef46872a5fa39e9d5ad5ab7a9"
 dependencies = [
- "cap-primitives",
- "cap-std",
- "rustix 0.38.26",
+ "cap-primitives 2.0.1",
+ "cap-std 2.0.1",
+ "rustix 0.38.31",
  "smallvec",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf30c373a3bee22c292b1b6a7a26736a38376840f1af3d2d806455edf8c3899"
+checksum = "fe16767ed8eee6d3f1f00d6a7576b81c226ab917eb54b96e5f77a5216ef67abb"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -346,16 +355,33 @@ dependencies = [
  "io-lifetimes 2.0.3",
  "ipnet",
  "maybe-owned",
- "rustix 0.38.26",
- "windows-sys 0.48.0",
+ "rustix 0.38.31",
+ "windows-sys 0.52.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a0b44fc796b1a84535a63753d50ba3972c4db55c7255c186f79140e63d56d0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 2.0.3",
+ "ipnet",
+ "maybe-owned",
+ "rustix 0.38.31",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
 [[package]]
 name = "cap-rand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577de6cff7c2a47d6b13efe5dd28bf116bd7f8f7db164ea95b7cc2640711f522"
+checksum = "20e5695565f0cd7106bc3c7170323597540e772bb73e0be2cd2c662a0f8fa4ca"
 dependencies = [
  "ambient-authority",
  "rand",
@@ -363,33 +389,47 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bade423fa6403efeebeafe568fdb230e8c590a275fba2ba978dd112efcf6e9"
+checksum = "593db20e4c51f62d3284bae7ee718849c3214f93a3b94ea1899ad85ba119d330"
 dependencies = [
- "cap-primitives",
+ "cap-primitives 2.0.1",
  "io-extras",
  "io-lifetimes 2.0.3",
- "rustix 0.38.26",
+ "rustix 0.38.31",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266626ce180cf9709f317d0bf9754e3a5006359d87f4bf792f06c9c5f1b63c0f"
+dependencies = [
+ "cap-primitives 3.0.0",
+ "io-extras",
+ "io-lifetimes 2.0.3",
+ "rustix 0.38.31",
 ]
 
 [[package]]
 name = "cap-time-ext"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f52b3c8f4abfe3252fd0a071f3004aaa3b18936ec97bdbd8763ce03aff6247"
+checksum = "03261630f291f425430a36f38c847828265bc928f517cdd2004c56f4b02f002b"
 dependencies = [
- "cap-primitives",
+ "ambient-authority",
+ "cap-primitives 2.0.1",
+ "iana-time-zone",
  "once_cell",
- "rustix 0.38.26",
+ "rustix 0.38.31",
  "winx",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
  "jobserver",
  "libc",
@@ -403,12 +443,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpp_demangle"
@@ -421,27 +467,27 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7c0d51205b863591dd1e7aaa0fb69c2ea7bed48ffa63d6c4a848b07a35a732"
+checksum = "16d5521e2abca66bbb1ddeecbb6f6965c79160352ae1579b39f8c86183895c24"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ffb467cbc25543e4c20d2ad669bf8275598047b03c89652ad5fe2a0f47fc0e1"
+checksum = "ef40a4338a47506e832ac3e53f7f1375bc59351f049a8379ff736dd02565bd95"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -451,7 +497,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.4",
  "log",
  "regalloc2",
  "smallvec",
@@ -460,33 +506,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7e74aed5c2b91e38d090653506afbd2cd3be1ff70593e2aa6bb82b3c6b77ff"
+checksum = "d24cd5d85985c070f73dfca07521d09086362d1590105ba44b0932bf33513b61"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff2dd24cce0775566da85770cb48aa58fef901cf2bff30275b42e7dbe62cbd5"
+checksum = "e0584c4363e3aa0a3c7cb98a778fbd5326a3709f117849a727da081d4051726c"
 
 [[package]]
 name = "cranelift-control"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bcf4d5c73bbca309edf3af2839b5218e5c74cfbf22b0ac492af8a1d11120d9"
+checksum = "f25ecede098c6553fdba362a8e4c9ecb8d40138363bff47f9712db75be7f0571"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286754159b1a685475d6a0b4710832f950d6f4846a817002e2c23ff001321a65"
+checksum = "6ea081a42f25dc4c5b248b87efdd87dcd3842a1050a37524ec5391e6172058cb"
 dependencies = [
  "serde",
  "serde_derive",
@@ -494,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67150a1fef9857caba710f8c0c8223d640f02c0e5d1ebbfc75ed62912599cb6b"
+checksum = "9796e712f5af797e247784f7518e6b0a83a8907d73d51526982d86ecb3a58b68"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -506,15 +552,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7ceea70d3e0d7f69df7657f99de902e32016731c5a8d2788c1df0215f00952"
+checksum = "f4a66ccad5782f15c80e9dd5af0df4acfe6e3eee98e8f7354a2e5c8ec3104bdd"
 
 [[package]]
 name = "cranelift-native"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707e5d9384ce4fa3c40af1abf4c3ec49857745cced5187593385f4a2c0b95445"
+checksum = "285e80df1d9b79ded9775b285df68b920a277b84f88a7228d2f5bc31fcdc58eb"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -523,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.104.1"
+version = "0.105.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d957e3ff2a14c2f974a66c22bfcedcd2bd0272af8dce4236869c3942f5a471"
+checksum = "4135b0ab01fd16aa8f8821196e9e2fe15953552ccaef8ba5153be0ced04ef757"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -539,45 +585,37 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -651,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encoding_rs"
@@ -688,9 +726,20 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "4.0.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -703,7 +752,17 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
- "event-listener 4.0.0",
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.2.0",
  "pin-project-lite",
 ]
 
@@ -730,12 +789,12 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fd-lock"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93f7a0db71c99f68398f80653ed05afb0b00e062e1a20c7ff849c4edfabbbcc"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix 0.38.26",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -755,15 +814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033b337d725b97690d86893f9de22b67b80dcc4e9ad815f348254c38119db8fb"
 dependencies = [
  "io-lifetimes 2.0.3",
- "rustix 0.38.26",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -775,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -785,15 +844,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -812,35 +871,34 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3831c2651acb5177cbd83943f3d9c8912c5ad03c76afcc0e9511ba568ec5ebb"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
  "futures-io",
- "memchr",
  "parking",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -864,7 +922,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "debugid",
  "fxhash",
  "serde",
@@ -883,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -926,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e57fa0ae458eb99874f54c09f4f9174f8b45fb87e854536a4e608696247f0c23"
 dependencies = [
  "ahash",
 ]
@@ -941,9 +999,32 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "id-arena"
@@ -963,12 +1044,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.4",
  "serde",
 ]
 
@@ -1025,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "ittapi"
@@ -1051,18 +1132,18 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1084,9 +1165,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libredox"
@@ -1094,7 +1175,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "libc",
  "redox_syscall",
 ]
@@ -1107,15 +1188,15 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "value-bag",
 ]
@@ -1137,9 +1218,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memfd"
@@ -1147,7 +1228,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.26",
+ "rustix 0.38.31",
 ]
 
 [[package]]
@@ -1161,18 +1242,18 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -1191,21 +1272,21 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.4",
  "indexmap",
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking"
@@ -1250,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "polling"
@@ -1272,14 +1353,14 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.3.1"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
+checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.26",
+ "rustix 0.38.31",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1292,9 +1373,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1310,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1349,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -1359,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1428,62 +1509,56 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "errno",
  "itoa",
  "libc",
- "linux-raw-sys 0.4.12",
+ "linux-raw-sys 0.4.13",
  "once_cell",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -1527,9 +1602,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -1543,12 +1618,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1576,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1587,44 +1662,44 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ce32341b2c0b70c144bbf35627fdc1ef18c76ced5e5e7b3ee8b5ba6b2ab6a0"
+checksum = "0682e006dd35771e392a6623ac180999a9a854b1d4a6c12fb2e804941c2b1f58"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "cap-fs-ext",
- "cap-std",
+ "cap-std 2.0.1",
  "fd-lock",
  "io-lifetimes 2.0.3",
- "rustix 0.38.26",
- "windows-sys 0.48.0",
+ "rustix 0.38.31",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1644,9 +1719,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1654,7 +1729,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "windows-sys 0.48.0",
 ]
 
@@ -1673,7 +1748,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1687,7 +1761,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1707,9 +1781,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -1719,9 +1793,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -1751,15 +1825,15 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "value-bag"
-version = "1.4.2"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
 
 [[package]]
 name = "version_check"
@@ -1780,41 +1854,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi-cap-std-sync"
-version = "17.0.1"
+name = "wasi-common"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025e842ba390587e523785ff58bd54fbbf1781b8d3072bc9aba4dc0b809f69da"
+checksum = "95e022c29ad56af4cc0a8a8f0e0191abf9e0a0c4a68d25dfe088c39c9a8e3d2c"
 dependencies = [
  "anyhow",
- "async-trait",
+ "bitflags 2.5.0",
  "cap-fs-ext",
  "cap-rand",
- "cap-std",
+ "cap-std 2.0.1",
  "cap-time-ext",
  "fs-set-times",
  "io-extras",
  "io-lifetimes 2.0.3",
- "once_cell",
- "rustix 0.38.26",
- "system-interface",
- "tracing",
- "wasi-common",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "wasi-common"
-version = "17.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4d4023cc65b3615590d38db0afb79234de09b3bb89cb0d8f83bdee9f5c28a8"
-dependencies = [
- "anyhow",
- "bitflags 2.4.1",
- "cap-rand",
- "cap-std",
- "io-extras",
  "log",
- "rustix 0.38.26",
+ "once_cell",
+ "rustix 0.38.31",
+ "system-interface",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -1824,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1834,24 +1891,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1861,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1871,47 +1928,57 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.38.1"
+version = "0.41.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
+checksum = "972f97a5d8318f908dded23594188a90bcd09365986b1163e66d70170e5287ae"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.201.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.118.1"
+version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ee9723b928e735d53000dec9eae7b07a60e490c85ab54abb66659fc61bfcd9"
+checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
+ "bitflags 2.5.0",
  "indexmap",
  "semver",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.75"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d027eb8294904fc715ac0870cebe6b0271e96b90605ee21511e7565c4ce568c"
+checksum = "60e73986a6b7fdfedb7c5bf9e7eb71135486507c8fbc4c0c42cffcb6532988b7"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -1919,10 +1986,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb6aa966be38f613954c3debe7ba6c7a02ffd0537432be438da0b038955cdf"
+checksum = "8106d7d22d63d1bcb940e22dcc7b03e46f0fc8bfbaf2fd7b6cb8f448f9449774"
 dependencies = [
+ "addr2line",
  "anyhow",
  "async-trait",
  "bincode",
@@ -1930,18 +1998,21 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "fxprof-processed-profile",
+ "gimli",
  "indexmap",
+ "ittapi",
  "libc",
  "log",
  "object",
  "once_cell",
  "paste",
  "rayon",
+ "rustix 0.38.31",
  "serde",
  "serde_derive",
  "serde_json",
  "target-lexicon",
- "wasm-encoder",
+ "wasm-encoder 0.41.2",
  "wasmparser",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -1949,7 +2020,8 @@ dependencies = [
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-fiber",
- "wasmtime-jit",
+ "wasmtime-jit-debug",
+ "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
  "wasmtime-winch",
  "wat",
@@ -1958,25 +2030,25 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1495ef4d46aec14f967b672e946e391dd8a14a443cda3d5e0779ff67fb6e28d"
+checksum = "3b0cf02cea951ace34ee3b0e64b7f446c3519d1c95ad75bc5330f405e275ee8f"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2de1b065bdbaca3df9e7e9f70eb129e326a99d971b16d666acd798d98d47635"
+checksum = "3249204a71d728d53fb3eea18afd0473f87e520445707a4d567ac4da0bb3eb5d"
 dependencies = [
  "anyhow",
  "base64",
  "bincode",
  "directories-next",
  "log",
- "rustix 0.38.26",
+ "rustix 0.38.31",
  "serde",
  "serde_derive",
  "sha2",
@@ -1987,14 +2059,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f19bcff82f81ba0273c0b68f3909977b0dd54489bc86c630d8aad43dca92f3f"
+checksum = "7d3786c0531565ec6c9852c0e46299f06cb6e4b58d36e30f3c234cfa69bde376"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -2002,15 +2074,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af072b7ad5ac5583e1f9e4737ebf88923de564fb5d4ace0ca9b4b720bdf95a1"
+checksum = "81eae2ec98027ee0b3950da83bc320120a23087ac4d39b3d59201cb5ebf52777"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df08a8bd9a68732577bee05ac685e4c247238b5e79ad9c062e2dfb4d04dca132"
+checksum = "595abdb067acdc812ab0f21d8d46d5aa4022392aa7c3e0632c20bff9ec49ffb4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2033,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404201c9e669083f189f01337b3ed0aa0eb081157fb4e170bbfe193df9497771"
+checksum = "e8c24c1fdea167b992d82ebe76471fd1cbe7b0b406bc72f9250f86353000134e"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2049,21 +2121,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e696b4911c9a69c3c2892ec05eb41bb15436d1a46d8830a755c40f5df47546a"
+checksum = "3279d510005358141550d8a90a5fc989d7e81748e5759d582fe6bfdcbf074a04"
 dependencies = [
  "anyhow",
+ "bincode",
+ "cpp_demangle",
  "cranelift-entity",
  "gimli",
  "indexmap",
  "log",
  "object",
+ "rustc-demangle",
  "serde",
  "serde_derive",
  "target-lexicon",
  "thiserror",
- "wasm-encoder",
+ "wasm-encoder 0.41.2",
  "wasmparser",
  "wasmprinter",
  "wasmtime-component-util",
@@ -2072,63 +2147,36 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a39681c1f6f54d1bf7efe5dc829f8d7fc0e2ca12c346fd7a3efbf726e9681d2"
+checksum = "9b1df665f2117741d1265f5663b0d93068b18120c2c4b18b9faed49d00d92c31"
 dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
- "rustix 0.38.26",
+ "rustix 0.38.31",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "wasmtime-jit"
-version = "17.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c56519882d936c680bd191d58ac04cff071a470eca2dcc664adcd60f986a731"
-dependencies = [
- "addr2line",
- "anyhow",
- "bincode",
- "cfg-if",
- "cpp_demangle",
- "gimli",
- "ittapi",
- "log",
- "object",
- "rustc-demangle",
- "rustix 0.38.26",
- "serde",
- "serde_derive",
- "target-lexicon",
- "wasmtime-environ",
- "wasmtime-jit-debug",
- "wasmtime-jit-icache-coherence",
- "wasmtime-runtime",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "wasmtime-jit-debug"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babc65e64ab0dd4e1ce65624db64e24ed0fbdebb16148729173fa0da9f70e53c"
+checksum = "63f307739370736e5b0cd2b45910ff96bcda6d5d68b2c4384bcedb0af4f3b321"
 dependencies = [
  "object",
  "once_cell",
- "rustix 0.38.26",
+ "rustix 0.38.31",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ec5b11c12d9acb09612e7ce04c4c8aea3e8dc79b2591ffdead986a5ce8ec49"
+checksum = "866634605089b4632b32226b54aa3670d72e1849f9fc425c7e50b3749c2e6df3"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2137,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e1c31bbdf67cb86f149bcead5193749f23f77c93c5244ec9ac8d192f90966c"
+checksum = "e11185c88cadf595d228f5ae4ff9b4badbf9ca98dcb37b0310c36e31fa74867f"
 dependencies = [
  "anyhow",
  "cc",
@@ -2153,9 +2201,9 @@ dependencies = [
  "memoffset",
  "paste",
  "psm",
- "rustix 0.38.26",
+ "rustix 0.38.31",
  "sptr",
- "wasm-encoder",
+ "wasm-encoder 0.41.2",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -2171,16 +2219,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-std",
- "cap-std",
+ "cap-std 3.0.0",
  "wasmtime",
  "wasmtime-wasi",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e799cff634d30fd042db96b417d515e54f903b95f8c1e0ec60e8f604479485"
+checksum = "f32377cbd827bee06fcb2f6bf97b0477fdcc86888bbe6db7b9cab8e644082e0a"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -2191,44 +2239,42 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10fe166d4e4c95d5d80c5b47e1e12256af2099ac525ddb9a19b1aeb8896e5e1"
+checksum = "4ab8d7566d206c42f8cf1d4ac90c5e40d3582e8eabad9b3b67e9e73c61fc47a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494f99111a165dcddc69aaa5fa23604f49dcfab479a869edd84581abd6ac569b"
+checksum = "9ca912bda309188bd25ab7652c6654b34aacdf43047c716ee1cb685a28079078"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
  "cap-rand",
- "cap-std",
+ "cap-std 2.0.1",
  "cap-time-ext",
  "fs-set-times",
  "futures",
  "io-extras",
  "io-lifetimes 2.0.3",
- "libc",
  "log",
  "once_cell",
- "rustix 0.38.26",
+ "rustix 0.38.31",
  "system-interface",
  "thiserror",
  "tokio",
  "tracing",
  "url",
- "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",
  "wiggle",
@@ -2237,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f5d76d399cb4423e6f178bc154a0e1c314711e28dabaa6e757e56628a083ec"
+checksum = "ba5a97bfccc241d1769cef75eb16f472a893982704d5f3c9c71c431c1484344a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2254,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb3bc92c031cf4961135bffe055a69c1bd67c253dca20631478189bb05ec27b"
+checksum = "faf2c76781a27e07802669f6f0e11eb4441546407eb65be60c3d862200988b92"
 dependencies = [
  "anyhow",
  "heck",
@@ -2266,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da08ab734954e16f57be38423b90c25a0b13420e51cbd0a2e37b86a468a988c"
+checksum = "3847d969bd203b8cd239f89581e52432a0f00b8c5c9bc917be2fccd7542c4f2f"
 
 [[package]]
 name = "wast"
@@ -2281,30 +2327,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "69.0.1"
+version = "201.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ee37317321afde358e4d7593745942c48d6d17e0e6e943704de9bbee121e7a"
+checksum = "1ef6e1ef34d7da3e2b374fd2b1a9c0227aff6cad596e1b24df9b58d0f6222faa"
 dependencies = [
+ "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.201.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.82"
+version = "1.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb338ee8dee4d4cd05e6426683f21c5087dc7cfc8903e839ccf48d43332da3c"
+checksum = "453d5b37a45b98dee4f4cb68015fc73634d7883bbef1c65e6e9c78d454cf3f32"
 dependencies = [
- "wast 69.0.1",
+ "wast 201.0.0",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2312,13 +2359,13 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5b200b5dd3d5d7cc4093166f4f916d2d2839296cf1b1757b9726635f6425c3"
+checksum = "7a7ecd6e1ffba1278cfd24a001a13da11d86801e0ad9342f11a370ce0df50e14"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -2327,28 +2374,28 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4dc34a2bc1091599de005e9b854cd1a9ea35b16ca51cac2797274c1a2666e06"
+checksum = "6c5490497a35d67040d4f2fd2491fbcad6dd225c5bd24681c2cd52a2f40a55ce"
 dependencies = [
  "anyhow",
  "heck",
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn 2.0.39",
+ "syn 2.0.53",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "17.0.1"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ba3b37f402a7513b9ed7973a6e907074987b3afdcede98d3d79939b3e76f1b"
+checksum = "d83f31d1c1a0d87842f1a2bf40bd230e25ba790c450f0d0ddb84524fd6955958"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
  "wiggle-generate",
 ]
 
@@ -2376,9 +2423,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.15.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d921185084e134e897e0e202e129a422306d0f1391954ecf4928d36defa897d"
+checksum = "1e0bd4d6cac8d69525d475d0ce1e0801eb6f314d42e764a52bd497ed3cb9c371"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2388,6 +2435,15 @@ dependencies = [
  "target-lexicon",
  "wasmparser",
  "wasmtime-environ",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2405,7 +2461,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2425,17 +2481,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -2446,9 +2502,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2458,9 +2514,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2470,9 +2526,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2482,9 +2538,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2494,9 +2550,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2506,9 +2562,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2518,9 +2574,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winx"
@@ -2528,15 +2584,15 @@ version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df6b7b28ce94b8be39d8df5cb21a08a4f3b9f33b631aedb4aa5776f785ead3"
+checksum = "316b36a9f0005f5aa4b03c39bc3728d045df136f8c13a73b7db4510dec725e08"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -2563,22 +2619,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.28"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.28"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.53",
 ]
 
 [[package]]

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -799,6 +799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +980,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1027,73 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1482,6 +1574,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,10 +1630,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -1625,6 +1764,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sptr"
@@ -1734,6 +1879,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,6 +1941,12 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1813,6 +1988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +2027,15 @@ name = "waker-fn"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2222,6 +2412,7 @@ dependencies = [
  "cap-std 3.0.0",
  "wasmtime",
  "wasmtime-wasi",
+ "wasmtime-wasi-http",
 ]
 
 [[package]]
@@ -2279,6 +2470,29 @@ dependencies = [
  "wasmtime",
  "wiggle",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "wasmtime-wasi-http"
+version = "18.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dbe5ffc98df206cdd791af8d3048d5e5d12376c995cb1e7348ad77023235264"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "wasmtime",
+ "wasmtime-wasi",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2356,6 +2570,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "wiggle"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.65"
 async-std = { version = "1.12.0", features = ["attributes"] }
-cap-std = "2.0.0"
-wasmtime = { version = "17.0.0", features = ["component-model"] }
-wasmtime-wasi =  "17.0.0"
+cap-std = "3.0.0"
+wasmtime = { version = "18.0.3", features = ["component-model"] }
+wasmtime-wasi =  "18.0.3"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -13,3 +13,4 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 cap-std = "3.0.0"
 wasmtime = { version = "18.0.3", features = ["component-model"] }
 wasmtime-wasi =  "18.0.3"
+wasmtime-wasi-http =  "18.0.3"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -34,16 +34,10 @@ async fn main() -> Result<()> {
         wasi: WasiCtx,
     }
     impl WasiView for CommandCtx {
-        fn table(&self) -> &ResourceTable {
-            &self.table
-        }
-        fn table_mut(&mut self) -> &mut ResourceTable {
+        fn table(&mut self) -> &mut ResourceTable {
             &mut self.table
         }
-        fn ctx(&self) -> &WasiCtx {
-            &self.wasi
-        }
-        fn ctx_mut(&mut self) -> &mut WasiCtx {
+        fn ctx(&mut self) -> &mut WasiCtx {
             &mut self.wasi
         }
     }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -3,7 +3,8 @@ use wasmtime::{
     component::{Component, Linker},
     Config, Engine, Store, WasmBacktraceDetails,
 };
-use wasmtime_wasi::preview2::{WasiCtxBuilder, ResourceTable, WasiCtx, WasiView, command};
+use wasmtime_wasi::preview2::{command, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
+use wasmtime_wasi_http::{proxy, WasiHttpCtx, WasiHttpView};
 
 wasmtime::component::bindgen!({
     world: "hello",
@@ -29,11 +30,12 @@ async fn main() -> Result<()> {
 
     let component = Component::from_file(&engine, "hello.component.wasm").unwrap();
 
-    struct CommandCtx {
+    struct CommandExtendedCtx {
         table: ResourceTable,
         wasi: WasiCtx,
+        wasi_http: WasiHttpCtx,
     }
-    impl WasiView for CommandCtx {
+    impl WasiView for CommandExtendedCtx {
         fn table(&mut self) -> &mut ResourceTable {
             &mut self.table
         }
@@ -41,18 +43,29 @@ async fn main() -> Result<()> {
             &mut self.wasi
         }
     }
+    impl WasiHttpView for CommandExtendedCtx {
+        fn table(&mut self) -> &mut ResourceTable {
+            &mut self.table
+        }
+        fn ctx(&mut self) -> &mut WasiHttpCtx {
+            &mut self.wasi_http
+        }
+    }
+
+    let wasi_http = WasiHttpCtx;
 
     command::add_to_linker(&mut linker)?;
+    proxy::add_only_http_to_linker(&mut linker)?;
     let mut store = Store::new(
         &engine,
-        CommandCtx {
+        CommandExtendedCtx {
             table,
             wasi,
+            wasi_http,
         },
     );
 
-    let (instance, _instance) =
-        Hello::instantiate_async(&mut store, &component, &linker).await?;
+    let (instance, _instance) = Hello::instantiate_async(&mut store, &component, &linker).await?;
 
     let res = instance.call_hello(&mut store, "ComponentizeJS").await?;
     println!("{}", res);

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -3,7 +3,7 @@ use wasmtime::{
     component::{Component, Linker},
     Config, Engine, Store, WasmBacktraceDetails,
 };
-use wasmtime_wasi::preview2::{WasiCtxBuilder, ResourceTable, WasiCtx, WasiView, command::add_to_linker};
+use wasmtime_wasi::preview2::{WasiCtxBuilder, ResourceTable, WasiCtx, WasiView, command};
 
 wasmtime::component::bindgen!({
     world: "hello",
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    add_to_linker(&mut linker)?;
+    command::add_to_linker(&mut linker)?;
     let mut store = Store::new(
         &engine,
         CommandCtx {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       ],
       "dependencies": {
         "@bytecodealliance/jco": "^1.0.2",
-        "@bytecodealliance/wizer": "^3.0.1"
+        "@bytecodealliance/wizer": "^3.0.1",
+        "es-module-lexer": "^1.4.1"
       },
       "devDependencies": {
         "@bytecodealliance/preview2-shim": "^0.15.1",
@@ -595,6 +596,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w=="
     },
     "node_modules/escalade": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "es-module-lexer": "^1.4.1"
   },
   "scripts": {
-    "build": "make",
+    "build": "make release",
+    "build:debug": "make debug",
     "test": "mocha -u tdd test/test.js --timeout 120000"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   },
   "dependencies": {
     "@bytecodealliance/jco": "^1.0.2",
-    "@bytecodealliance/wizer": "^3.0.1"
+    "@bytecodealliance/wizer": "^3.0.1",
+    "es-module-lexer": "^1.4.1"
   },
   "scripts": {
-    "build": "cargo build --release --target wasm32-wasi && make -j",
+    "build": "make",
     "test": "mocha -u tdd test/test.js --timeout 120000"
   },
   "files": [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.76.0"
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "1.76.0"
+channel = "stable"
 targets = [ "wasm32-unknown-unknown" ]
-profile = "minimal"

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -7,13 +7,16 @@ import {
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { resolve, join } from 'node:path';
-import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import {
   spliceBindings,
   stubWasi,
 } from '../lib/spidermonkey-embedding-splicer.js';
 import { fileURLToPath } from 'node:url';
 import { stdout, stderr, exit, platform } from 'node:process';
+import { init as lexerInit, parse } from 'es-module-lexer';
 const { version } = JSON.parse(
   await readFile(new URL('../package.json', import.meta.url), 'utf8')
 );
@@ -28,7 +31,7 @@ export async function componentize(jsSource, witWorld, opts) {
     debug = false,
     sourceName = 'source.js',
     engine = fileURLToPath(
-      new URL('../lib/spidermonkey_embedding.wasm', import.meta.url)
+      new URL('../lib/starlingmonkey_embedding.debug.wasm', import.meta.url)
     ),
     preview2Adapter = preview1AdapterReactorPath(),
     witPath,
@@ -61,19 +64,52 @@ export async function componentize(jsSource, witWorld, opts) {
     console.log(exports);
   }
 
-  const input = join(tmpdir(), 'in.wasm');
-  const output = join(tmpdir(), 'out.wasm');
+  const tmpDir = join(
+    tmpdir(),
+    createHash('sha256')
+      .update(Math.random().toString())
+      .digest('hex')
+      .slice(0, 12)
+  );
+  await mkdir(tmpDir);
+
+  const input = join(tmpDir, 'in.wasm');
+  const output = join(tmpDir, 'out.wasm');
 
   await writeFile(input, Buffer.from(wasm));
 
-  // we concatenate the sources into stdin for wizering, communicating the offsets via env vars
-  let wizerInput = jsSource + jsBindings;
+  // rewrite the JS source import specifiers to reference import wrappers
+  await lexerInit;
+  const [jsImports] = parse(jsSource);
+  let source = '',
+    curIdx = 0;
+  for (const jsImpt of jsImports) {
+    const specifier = jsSource.slice(jsImpt.s, jsImpt.e);
+    source += jsSource.slice(curIdx, jsImpt.s);
+    source += `./${specifier.replace(':', '__').replace('/', '$')}.js`;
+    curIdx = jsImpt.e;
+  }
+  source += jsSource.slice(curIdx);
+
+  // write the source files into the source dir
+  const sourceDir = join(tmpDir, 'sources');
+  await mkdir(sourceDir);
+  await Promise.all(
+    [
+      [sourceName, source],
+      [sourceName.slice(0, -3) + '.bindings.js', jsBindings],
+      ...importWrappers.map(([sourceName, source]) => [
+        `./${sourceName.replace(':', '__').replace('/', '$')}.js`,
+        source,
+      ]),
+    ].map(async ([sourceName, source]) =>
+      writeFile(join(sourceDir, sourceName), source)
+    )
+  );
 
   const env = {
     DEBUG: debug ? '1' : '',
     SOURCE_NAME: sourceName,
-    SOURCE_LEN: new TextEncoder().encode(jsSource).byteLength.toString(),
-    BINDINGS_LEN: new TextEncoder().encode(jsBindings).byteLength.toString(),
     IMPORT_WRAPPER_CNT: Object.keys(importWrappers).length.toString(),
     EXPORT_CNT: exports.length.toString(),
   };
@@ -84,14 +120,6 @@ export async function componentize(jsSource, witWorld, opts) {
       (expt.paramptr ? '*' : '') + expt.params.join(',');
     env[`EXPORT${idx}_RET`] = (expt.retptr ? '*' : '') + (expt.ret || '');
     env[`EXPORT${idx}_RETSIZE`] = String(expt.retsize);
-  }
-
-  for (const [idx, [name, importWrapper]] of importWrappers.entries()) {
-    env[`IMPORT_WRAPPER${idx}_NAME`] = name;
-    env[`IMPORT_WRAPPER${idx}_LEN`] = new TextEncoder()
-      .encode(importWrapper)
-      .byteLength.toString();
-    wizerInput += importWrapper;
   }
 
   for (let i = 0; i < imports.length; i++) {
@@ -110,7 +138,9 @@ export async function componentize(jsSource, witWorld, opts) {
       wizer,
       [
         '--allow-wasi',
-        `--dir=.`,
+        '--init-func',
+        'componentize.wizer',
+        `--dir=${sourceDir}`,
         `--wasm-bulk-memory=true`,
         '--inherit-env=true',
         `-o=${output}`,
@@ -119,7 +149,7 @@ export async function componentize(jsSource, witWorld, opts) {
       {
         stdio: [null, stdout, stderr],
         env,
-        input: wizerInput,
+        input: join(sourceDir, sourceName.slice(0, -3) + '.bindings.js'),
         shell: true,
         encoding: 'utf-8',
       }
@@ -127,23 +157,20 @@ export async function componentize(jsSource, witWorld, opts) {
     if (wizerProcess.status !== 0)
       throw new Error('Wizering failed to complete');
   } catch (error) {
-    console.error(
-      `Error: Failed to initialize the compiled Wasm binary with Wizer:\n`,
-      error.message
-    );
+    let err =
+      `Failed to initialize the compiled Wasm binary with Wizer:\n` +
+      error.message;
     if (debug) {
-      console.error(`Binary available for debugging at ${input}`);
+      err += `\nBinary and sources available for debugging at ${tmpDir}\n`;
     } else {
-      await unlink(input);
+      rmSync(tmpDir, { recursive: true });
     }
-    exit(1);
+    throw new Error(err);
   }
 
   const bin = await readFile(output);
 
-  const unlinkPromises = Promise.all([unlink(input), unlink(output)]).catch(
-    () => {}
-  );
+  const tmpdirRemovePromise = rm(tmpDir, { recursive: true });
 
   // Check for initialization errors
   // By actually executing the binary in a mini sandbox to get back
@@ -153,7 +180,7 @@ export async function componentize(jsSource, witWorld, opts) {
     getStderr,
   } = await initWasm(bin);
 
-  await unlinkPromises;
+  await tmpdirRemovePromise;
 
   async function initWasm(bin) {
     const eep = (name) => () => {
@@ -163,7 +190,7 @@ export async function componentize(jsSource, witWorld, opts) {
     };
 
     let stderr = '';
-    const module = await WebAssembly.compile(bin);
+    const wasmModule = await WebAssembly.compile(bin);
 
     const mockImports = {
       // "wasi-logging2": {
@@ -185,31 +212,15 @@ export async function componentize(jsSource, witWorld, opts) {
           mem.setUint32(nwritten, written, true);
           return 1;
         },
-        environ_get: eep('environ_get'),
-        environ_sizes_get: eep('environ_sizes_get'),
-        clock_res_get: eep('clock_res_get'),
-        clock_time_get: eep('clock_time_get'),
-        fd_close: eep('fd_close'),
-        fd_fdstat_get: eep('fd_fdstat_get'),
-        fd_fdstat_set_flags: eep('fd_fdstat_set_flags'),
-        fd_prestat_get: eep('fd_prestat_get'),
-        fd_prestat_dir_name: eep('fd_prestat_dir_name'),
-        fd_read: eep('fd_read'),
-        fd_seek: eep('fd_seek'),
-        path_open: eep('path_open'),
-        path_remove_directory: eep('path_remove_directory'),
-        path_unlink_file: eep('path_unlink_file'),
-        proc_exit: eep('proc_exit'),
-        random_get: eep('random_get'),
       },
     };
 
-    for (const [importName, binding] of imports) {
-      mockImports[importName] = mockImports[importName] || {};
-      mockImports[importName][binding] = eep(binding);
+    for (const { module, name } of WebAssembly.Module.imports(wasmModule)) {
+      mockImports[module] = mockImports[module] || {};
+      if (!mockImports[module][name]) mockImports[module][name] = eep(name);
     }
 
-    const { exports } = await WebAssembly.instantiate(module, mockImports);
+    const { exports } = await WebAssembly.instantiate(wasmModule, mockImports);
     return {
       exports,
       getStderr() {

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -31,7 +31,7 @@ export async function componentize(jsSource, witWorld, opts) {
     debug = false,
     sourceName = 'source.js',
     engine = fileURLToPath(
-      new URL('../lib/starlingmonkey_embedding.debug.wasm', import.meta.url)
+      new URL('../lib/starlingmonkey_embedding.wasm', import.meta.url)
     ),
     preview2Adapter = preview1AdapterReactorPath(),
     witPath,
@@ -93,6 +93,11 @@ export async function componentize(jsSource, witWorld, opts) {
 
   // write the source files into the source dir
   const sourceDir = join(tmpDir, 'sources');
+
+  if (debug) {
+    console.log(`> Writing sources to ${tmpDir}/sources`);
+  }
+  
   await mkdir(sourceDir);
   await Promise.all(
     [
@@ -170,7 +175,7 @@ export async function componentize(jsSource, witWorld, opts) {
 
   const bin = await readFile(output);
 
-  const tmpdirRemovePromise = rm(tmpDir, { recursive: true });
+  const tmpdirRemovePromise = debug ? Promise.resolve() : rm(tmpDir, { recursive: true });
 
   // Check for initialization errors
   // By actually executing the binary in a mini sandbox to get back

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -359,7 +359,7 @@ export async function componentize(jsSource, witWorld, opts) {
     exit(1);
   }
 
-  // after wizering, stub out the wasi imports
+  // after wizering, stub out the wasi preview1 imports
   const finalBin = stubWasi(bin, enableStdout);
 
   const component = await metadataAdd(

--- a/test/builtins/console-object.js
+++ b/test/builtins/console-object.js
@@ -50,6 +50,6 @@ export const source = `
 
 export async function test (run) {
   const { stdout, stderr } = await run();
-  strictEqual(stdout, `{ a: { value: "a" }, b: { c: "d" }, e: ["f"], g: [{ g: "i" }], l: [Function l], m: [Getter], n: [Getter], o: [Function], p: [Function], q: 5, s: 29879287298374924, t: Set(3) { 1, 2, 3 }, u: Map(3) { 1 => 2, 3 => 4, [Function foo] => {} }, v: Symbol.for("blah"), w: Symbol(), x: undefined, y: null, z: URL { hash: "", host: "site.com", hostname: "site.com", href: "https://site.com/x?a&b", origin: "https://site.com", password: "", pathname: "/x", port: "", protocol: "https:", search: "?a&b", searchParams: {}, username: "" }, zz: Uint8Array [1, 2, 3], zzz: Z {} }\n`);
+  strictEqual(stdout, `{ a: { value: "a" }, b: { c: "d" }, e: ["f"], g: [{ g: "i" }], l: [Function l], m: [Getter], n: [Getter], o: [Function], p: [Function], q: 5, s: 29879287298374924, t: Set(3) { 1, 2, 3 }, u: Map(3) { 1 => 2, 3 => 4, [Function foo] => {} }, v: Symbol.for("blah"), w: Symbol(), x: undefined, y: null, z: URL { hash: "", host: "site.com", hostname: "site.com", href: "https://site.com/x?a&b", origin: "https://site.com", password: "", pathname: "/x", port: "", protocol: "https:", search: "?a&b", searchParams: URLSearchParams {}, username: "" }, zz: Uint8Array [1, 2, 3], zzz: Z {} }\n`);
   strictEqual(stderr, '');
 }


### PR DESCRIPTION
Updates ComponentizeJS to use the [StarlingMonkey engine base](https://github.com/fermyon/starlingMonkey) instead of Fastly's JS Compute Runtime shared builtins archive.

Based to the upstream PRs to StarlingMonkey at https://github.com/fermyon/StarlingMonkey/pull/11 and https://github.com/fermyon/StarlingMonkey/pull/12.