### PR TITLE
do not stub imports that are part of the target world

### DIFF
--- a/crates/spidermonkey-embedding-splicer/src/lib.rs
+++ b/crates/spidermonkey-embedding-splicer/src/lib.rs
@@ -94,8 +94,14 @@ fn parse_wit(path: &Path) -> Result<(Resolve, PackageId)> {
 }
 
 impl Guest for SpidermonkeyEmbeddingSplicerComponent {
-    fn stub_wasi(wasm: Vec<u8>, features: Vec<Features>) -> Result<Vec<u8>, String> {
-        stub_wasi(wasm, features).map_err(|e| e.to_string())
+    fn stub_wasi(
+        wasm: Vec<u8>,
+        features: Vec<Features>,
+        wit_source: Option<String>,
+        wit_path: Option<String>,
+        world_name: Option<String>,
+    ) -> Result<Vec<u8>, String> {
+        stub_wasi(wasm, features, wit_source, wit_path, world_name).map_err(|e| e.to_string())
     }
 
     fn splice_bindings(

--- a/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
+++ b/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
@@ -31,7 +31,7 @@ world spidermonkey-embedding-splicer {
     imports: list<tuple<string, string, u32>>,
   }
 
-  export stub-wasi: func(engine: list<u8>, features: list<features>) -> result<list<u8>, string>;
+  export stub-wasi: func(engine: list<u8>, features: list<features>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>) -> result<list<u8>, string>;
 
   export splice-bindings: func(source-name: option<string>, spidermonkey-engine: list<u8>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>, debug: bool) -> result<splice-result, string>;
 }

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -24,7 +24,7 @@ const isWindows = platform === 'win32';
 const DEBUG_BINDINGS = false;
 const DEBUG_CALLS = false;
 
-function maybeWindowsPath (path) {
+function maybeWindowsPath(path) {
   if (!path) return path;
   if (!isWindows) return resolve(path);
   return '//?/' + resolve(path).replace(/\\/g, '/');
@@ -314,7 +314,9 @@ export async function componentize(jsSource, witWorld, opts) {
   }
 
   // after wizering, stub out the wasi imports depending on what features are enabled
-  const finalBin = stubWasi(bin, features);
+  const finalBin = stubWasi(bin, features, witWorld,
+    maybeWindowsPath(witPath),
+    worldName,);
 
   const component = await metadataAdd(
     await componentNew(


### PR DESCRIPTION
This PR makes sure that if an import is present in the target world, it does not get stubbed out. I went with a different approach than what was suggested in the [issue comment](https://github.com/bytecodealliance/ComponentizeJS/issues/105#issuecomment-2110865818) as I noticed the module only contained the wasi imports if they are a part of the target world and was simpler than having to prepare the `wit`. Let me know if I am missing something. 

fixes #105 