### PR TITLE
use the Bytecode Alliance org repository for StarlingMonkey

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "StarlingMonkey"]
 	path = StarlingMonkey
-	url = git@github.com:fermyon/StarlingMonkey
+	url = git@github.com:bytecodealliance/StarlingMonkey


### PR DESCRIPTION
Update the submodule to point directly at the BA project instead of relying on GitHub redirects as there is now a fork in the `fermyon` org. 