### PR TITLE
add option to retain fetchEvent handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Setting `disableFeatures: ['random', 'stdio', 'clocks']` will disable all featur
 
 Note that pure components **will not report errors and will instead trap**, so that this should only be enabled after very careful testing.
 
+The features that are not included by default are:
+* `'http'` - Support for sending and receiving HTTP requests, depends on `wasi:io` 
+* `'fetch-event'` - Enables using `fetchEvent` to respond to `wasi:http/incoming-handler@0.2.0#handle`. If the target world does note export `wasi:http/incoming-handler@0.2.0`, this will be ignored.
+
 Note that features explicitly imported by the target world cannot be disabled - if you target a component to a world
 that imports `wasi:clocks`, then `disableFeatures: ['clocks']` will not be supported.
 

--- a/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
+++ b/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
@@ -33,5 +33,5 @@ world spidermonkey-embedding-splicer {
 
   export stub-wasi: func(engine: list<u8>, features: list<features>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>) -> result<list<u8>, string>;
 
-  export splice-bindings: func(source-name: option<string>, spidermonkey-engine: list<u8>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>, debug: bool) -> result<splice-result, string>;
+  export splice-bindings: func(source-name: option<string>, spidermonkey-engine: list<u8>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>, debug: bool, retain-fetch-event: bool ) -> result<splice-result, string>;
 }

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -45,6 +45,7 @@ export async function componentize(jsSource, witWorld, opts) {
     worldName,
     disableFeatures = [],
     enableFeatures = [],
+    retainFetchEvent = false
   } = opts || {};
 
   let { wasm, jsBindings, importWrappers, exports, imports } = spliceBindings(
@@ -53,7 +54,8 @@ export async function componentize(jsSource, witWorld, opts) {
     witWorld,
     maybeWindowsPath(witPath),
     worldName,
-    false
+    false,
+    retainFetchEvent
   );
 
   // we never disable a feature that is already in the target world usage

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -45,8 +45,9 @@ export async function componentize(jsSource, witWorld, opts) {
     worldName,
     disableFeatures = [],
     enableFeatures = [],
-    retainFetchEvent = false
   } = opts || {};
+
+  const retainFetchEvent = enableFeatures.includes('fetch-event')
 
   let { wasm, jsBindings, importWrappers, exports, imports } = spliceBindings(
     sourceName,


### PR DESCRIPTION
This PR adds the ability to use the `fetchEvent` Handler provided by `StarlingMonkey`. 

fixes #114 