### PR TITLE
fix: disable http by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ export function componentize(jsSource: string, opts: {
 }
 ```
 
+`http` provides support for the host APIs used by the `fetch` method and is disabled by default,
+while this API is still being developed. Contributions very welcome to improve `fetch` support.
+
 Converts a JS source into a component binary.
 
 Imports provides the list of used guest imports only, while the StarlingMonkey engine may pull in additional

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ export function componentize(jsSource: string, opts: {
   engine?: string,
   preview2Adapter?: string,
   disableFeatures?: ('stdio' | 'random' | 'clocks')[],
+  enableFeatures?: ('http')[],
 }): {
   component: Uint8Array,
   imports: string[]

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -88,9 +88,9 @@ export async function componentize(jsSource, witWorld, opts) {
   if (!disableFeatures.includes('clocks')) {
     features.push('clocks');
   }
-  if (!disableFeatures.includes('http')) {
+  // if (enableFeatures.includes('http')) {
     features.push('http');
-  }
+  // }
 
   if (DEBUG_BINDINGS) {
     console.log('--- JS Source ---');

--- a/test/cases/http-request/test.js
+++ b/test/cases/http-request/test.js
@@ -1,5 +1,7 @@
 import { ok } from 'node:assert';
 
+export const enableFeatures = ['http'];
+
 export function test (instance) {
   ok(instance.getResult().includes('"content-type":"text/html'));
   ok(instance.getResult().includes('WebAssembly'));


### PR DESCRIPTION
HTTP is still not properly working, so should be marked as experimental and a disabled feature by default until we can properly figure out the async model and remaining bugs.