### PR TITLE
allow  using fetchEvent for wasi:http/incoming-handler@0.2.0 optionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Note that pure components **will not report errors and will instead trap**, so t
 Note that features explicitly imported by the target world cannot be disabled - if you target a component to a world
 that imports `wasi:clocks`, then `disableFeatures: ['clocks']` will not be supported.
 
+## Using StarlingMonkey's `fetch-event`
+
+The StarlingMonkey engine provides the ability to use `fetchEvent` to handle calls to `wasi:http/incoming-handler@0.2.0#handle`. When targeting worlds that export `wasi:http/incoming-handler@0.2.0`, the component will use the `fetchEvent` if the guest content does not explicitly export a `incomingHandler` or `wasi:http/incoming-handler@0.2.0` object. Using the `fetchEvent` requires enabling the `http` feature. 
+
 ## API
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ that imports `wasi:clocks`, then `disableFeatures: ['clocks']` will not be suppo
 
 ## Using StarlingMonkey's `fetch-event`
 
-The StarlingMonkey engine provides the ability to use `fetchEvent` to handle calls to `wasi:http/incoming-handler@0.2.0#handle`. When targeting worlds that export wasi:http/incoming-handker@0.2.0 the fetch event will automatically be attached. Alternatively, to override the fetch event with a custom handler, export an explict incomingHandler or wasi:http/incoming-handler@0.2.0 object. Using the `fetchEvent` requires enabling the `http` feature. 
+The StarlingMonkey engine provides the ability to use `fetchEvent` to handle calls to `wasi:http/incoming-handler@0.2.0#handle`. When targeting worlds that export `wasi:http/incoming-handler@0.2.0` the fetch event will automatically be attached. Alternatively, to override the fetch event with a custom handler, export an explict `incomingHandler` or `'wasi:http/incoming-handler@0.2.0'` object. Using the `fetchEvent` requires enabling the `http` feature. 
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ that imports `wasi:clocks`, then `disableFeatures: ['clocks']` will not be suppo
 
 ## Using StarlingMonkey's `fetch-event`
 
-The StarlingMonkey engine provides the ability to use `fetchEvent` to handle calls to `wasi:http/incoming-handler@0.2.0#handle`. When targeting worlds that export `wasi:http/incoming-handler@0.2.0`, the component will use the `fetchEvent` if the guest content does not explicitly export a `incomingHandler` or `wasi:http/incoming-handler@0.2.0` object. Using the `fetchEvent` requires enabling the `http` feature. 
+The StarlingMonkey engine provides the ability to use `fetchEvent` to handle calls to `wasi:http/incoming-handler@0.2.0#handle`. When targeting worlds that export wasi:http/incoming-handker@0.2.0 the fetch event will automatically be attached. Alternatively, to override the fetch event with a custom handler, export an explict incomingHandler or wasi:http/incoming-handler@0.2.0 object. Using the `fetchEvent` requires enabling the `http` feature. 
 
 ## API
 

--- a/crates/spidermonkey-embedding-splicer/src/bindgen.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bindgen.rs
@@ -385,6 +385,11 @@ impl JsBindgen<'_> {
                         if let Some(name) = iface.name.as_ref() {
                             let camel_case_name = name.to_lower_camel_case();
                             if !guest_exports.contains(&camel_case_name) {
+                                if name == "incoming-handler"
+                                    || name == "wasi:http/incoming-handler@0.2.0"
+                                {
+                                    continue;
+                                }
                                 bail!("Expected a JS export definition for '{}'", camel_case_name);
                             }
                             // TODO: move populate_export_aliases to a preprocessing

--- a/crates/spidermonkey-embedding-splicer/src/bindgen.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bindgen.rs
@@ -387,16 +387,16 @@ impl JsBindgen<'_> {
                 WorldKey::Interface(iface) => {
                     if !guest_exports.contains(&name) {
                         let iface = &self.resolve.interfaces[*iface];
-                        if let Some(name) = iface.name.as_ref() {
-                            let camel_case_name = name.to_lower_camel_case();
+                        if let Some(iface_name) = iface.name.as_ref() {
+                            let camel_case_name = iface_name.to_lower_camel_case();
                             if !guest_exports.contains(&camel_case_name) {
                                 // For wasi:http/incoming-handler, we treat it
                                 // as a special case as the engine already
                                 // provides the export using fetchEvent and that
                                 // can be used when an explicit export is not
                                 // defined by the guest content.
-                                if name == "incoming-handler"
-                                    || name == "wasi:http/incoming-handler@0.2.0"
+                                if iface_name == "incoming-handler"
+                                    || iface_name == "wasi:http/incoming-handler@0.2.0"
                                 {
                                     if !features.contains(&Features::Http) {
                                         bail!(

--- a/crates/spidermonkey-embedding-splicer/src/bindgen.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bindgen.rs
@@ -385,6 +385,11 @@ impl JsBindgen<'_> {
                         if let Some(name) = iface.name.as_ref() {
                             let camel_case_name = name.to_lower_camel_case();
                             if !guest_exports.contains(&camel_case_name) {
+                                // For wasi:http/incoming-handler, we treat it
+                                // as a special case as the engine already
+                                // provides the export using fetchEvent and that
+                                // can be used when an explicit export is not
+                                // defined by the guest content.
                                 if name == "incoming-handler"
                                     || name == "wasi:http/incoming-handler@0.2.0"
                                 {

--- a/crates/spidermonkey-embedding-splicer/src/bindgen.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bindgen.rs
@@ -396,7 +396,7 @@ impl JsBindgen<'_> {
                                 // can be used when an explicit export is not
                                 // defined by the guest content.
                                 if iface_name == "incoming-handler"
-                                    || iface_name == "wasi:http/incoming-handler@0.2.0"
+                                    || name == "wasi:http/incoming-handler@0.2.0"
                                 {
                                     if !features.contains(&Features::Http) {
                                         bail!(

--- a/crates/spidermonkey-embedding-splicer/src/lib.rs
+++ b/crates/spidermonkey-embedding-splicer/src/lib.rs
@@ -115,6 +115,7 @@ impl Guest for SpidermonkeyEmbeddingSplicerComponent {
         world_name: Option<String>,
         mut guest_imports: Vec<String>,
         guest_exports: Vec<String>,
+        features: Vec<Features>,
         debug: bool,
     ) -> Result<SpliceResult, String> {
         let source_name = source_name.unwrap_or("source.js".to_string());
@@ -194,6 +195,7 @@ impl Guest for SpidermonkeyEmbeddingSplicerComponent {
             &source_name,
             &guest_imports,
             &guest_exports,
+            features,
         )
         .map_err(|err| err.to_string())?;
 

--- a/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
+++ b/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
@@ -33,5 +33,5 @@ world spidermonkey-embedding-splicer {
 
   export stub-wasi: func(engine: list<u8>, features: list<features>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>) -> result<list<u8>, string>;
 
-  export splice-bindings: func(source-name: option<string>, spidermonkey-engine: list<u8>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>, guest-imports: list<string>, guest-exports: list<string>, debug: bool) -> result<splice-result, string>;
+  export splice-bindings: func(source-name: option<string>, spidermonkey-engine: list<u8>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>, guest-imports: list<string>, guest-exports: list<string>, features: list<features>,  debug: bool) -> result<splice-result, string>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bytecodealliance/componentize-js",
-  "version": "0.8.3",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/componentize-js",
-      "version": "0.8.3",
+      "version": "0.10.0",
       "workspaces": [
         "."
       ],

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -66,16 +66,6 @@ export async function componentize(jsSource, witWorld, opts) {
     guestExports.push(k.n);
   });
 
-  let { wasm, jsBindings, importWrappers, exports, imports } = spliceBindings(
-    sourceName,
-    await readFile(engine),
-    witWorld,
-    maybeWindowsPath(witPath),
-    worldName,
-    guestImports,
-    guestExports,
-    false
-  );
 
   // we never disable a feature that is already in the target world usage
   const features = [];
@@ -91,6 +81,19 @@ export async function componentize(jsSource, witWorld, opts) {
   if (enableFeatures.includes('http')) {
     features.push('http');
   }
+
+  let { wasm, jsBindings, importWrappers, exports, imports } = spliceBindings(
+    sourceName,
+    await readFile(engine),
+    witWorld,
+    maybeWindowsPath(witPath),
+    worldName,
+    guestImports,
+    guestExports,
+    features,
+    false
+  );
+
 
   if (DEBUG_BINDINGS) {
     console.log('--- JS Source ---');


### PR DESCRIPTION
This PR adds the ability to use the `fetchEvent` from StarlingMonkey to handle incoming HTTP requests. This needs the `http` feature to be enabled explicitly.  