### PR TITLE
chore: add NPM description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@bytecodealliance/componentize-js",
   "version": "0.13.0",
   "homepage": "https://github.com/bytecodealliance/componentize-js#readme",
+  "description": "ESM -> WebAssembly Component creator, via a SpiderMonkey JS engine embedding",
   "type": "module",
   "exports": "./src/componentize.js",
   "devDependencies": {


### PR DESCRIPTION
This commit adds the description field to ensure that componentize-js doesn't show HTML in NPM search.

e.g.
![image](https://github.com/user-attachments/assets/c7a9ad14-363b-4979-8f83-265b24ded564)
