### PR TITLE
fix: ensure resource imports and exports use kebab case

### DIFF
--- a/crates/spidermonkey-embedding-splicer/src/bindgen.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bindgen.rs
@@ -252,30 +252,32 @@ pub fn componentize_bindgen(
                     let iface_prefix = interface_name(resolve, *iface_id)
                         .map(|s| format!("{s}$"))
                         .unwrap_or_else(String::new);
-                    let resource_name = ty.name.as_ref().unwrap().to_lower_camel_case();
+                    let resource_name_camel = ty.name.as_ref().unwrap().to_lower_camel_case();
+                    let resource_name_kebab = ty.name.as_ref().unwrap().to_kebab_case();
                     let module_name = format!("[export]{key_name}");
-                    resource_bindings.push(format!("{iface_prefix}new${resource_name}"));
+                    resource_bindings.push(format!("{iface_prefix}new${resource_name_camel}"));
                     resource_imports.push((
                         module_name.clone(),
-                        format!("[resource-new]{resource_name}"),
+                        format!("[resource-new]{resource_name_kebab}"),
                         1,
                     ));
-                    resource_bindings.push(format!("{iface_prefix}rep${resource_name}"));
+                    resource_bindings.push(format!("{iface_prefix}rep${resource_name_camel}"));
                     resource_imports.push((
                         module_name.clone(),
-                        format!("[resource-rep]{resource_name}"),
+                        format!("[resource-rep]{resource_name_kebab}"),
                         1,
                     ));
-                    resource_bindings.push(format!("export${iface_prefix}drop${resource_name}"));
+                    resource_bindings
+                        .push(format!("export${iface_prefix}drop${resource_name_camel}"));
                     resource_imports.push((
                         module_name.clone(),
-                        format!("[resource-drop]{resource_name}"),
+                        format!("[resource-drop]{resource_name_kebab}"),
                         0,
                     ));
                     finalization_registries.push(format!(
-                        "const finalizationRegistry_export${iface_prefix}{resource_name} = \
+                        "const finalizationRegistry_export${iface_prefix}{resource_name_camel} = \
                          new FinalizationRegistry((handle) => {{
-                             $resource_export${iface_prefix}drop${resource_name}(handle);
+                             $resource_export${iface_prefix}drop${resource_name_camel}(handle);
                          }});
                         "
                     ));
@@ -312,6 +314,7 @@ pub fn componentize_bindgen(
         let resource_name = ty.name.as_deref().unwrap();
         let prefix = prefix.as_deref().unwrap_or("");
         let resource_name_camel = resource_name.to_lower_camel_case();
+        let resource_name_kebab = resource_name.to_kebab_case();
 
         finalization_registries.push(format!(
             "const finalizationRegistry_import${prefix}{resource_name_camel} = \
@@ -323,7 +326,7 @@ pub fn componentize_bindgen(
         resource_bindings.push(format!("import${prefix}drop${resource_name_camel}"));
         resource_imports.push((
             imported_resource_modules.get(&id).unwrap().clone(),
-            format!("[resource-drop]{resource_name}"),
+            format!("[resource-drop]{resource_name_kebab}"),
             0,
         ));
     }

--- a/test/cases/resource-floats/resource-floats-imports.js
+++ b/test/cases/resource-floats/resource-floats-imports.js
@@ -1,4 +1,4 @@
-export class Float {
+export class MyFloat {
     constructor(value) {
         this.value = value + 2
     }
@@ -8,6 +8,6 @@ export class Float {
     }
 
     static add(a, b) {
-        return new Float(a.value + b + 6)
+        return new MyFloat(a.value + b + 6)
     }
 }

--- a/test/cases/resource-floats/resource-floats.js
+++ b/test/cases/resource-floats/resource-floats.js
@@ -1,4 +1,4 @@
-export class Float {
+export class MyFloat {
     constructor(value) {
         this.value = value + 1
     }

--- a/test/cases/resource-floats/source.js
+++ b/test/cases/resource-floats/source.js
@@ -1,9 +1,9 @@
-import { Float as ImportFloat } from "resource-floats-imports";
-import { Float as ImportFloat2 } from "test:test/resource-floats";
+import { MyFloat as ImportFloat } from "resource-floats-imports";
+import { MyFloat as ImportFloat2 } from "test:test/resource-floats";
 
 const symbolDispose = Symbol.for('dispose');
 
-class Float {
+class MyFloat {
     constructor(value) {
         this.value = new ImportFloat(value + 1);
     }
@@ -13,11 +13,11 @@ class Float {
     }
 
     static add(a, b) {
-        return new Float(ImportFloat.add(a.value, b).get() + 5);
+        return new MyFloat(ImportFloat.add(a.value, b).get() + 5);
     }
 }
 
-export const resourceFloatsExports = { Float }
+export const resourceFloatsExports = { MyFloat }
 
 export function add(a, b) {
     const out = new ImportFloat2(a.get() + b.get() + 5);

--- a/test/cases/resource-floats/test.js
+++ b/test/cases/resource-floats/test.js
@@ -1,19 +1,19 @@
 import { strictEqual } from 'node:assert';
-import { Float as HostFloat } from "./resource-floats.js";
+import { MyFloat as HostFloat } from "./resource-floats.js";
 
 export function test(instance) {
-    const { Float } = instance.resourceFloatsExports;
+    const { MyFloat } = instance.resourceFloatsExports;
 
     let float1 = new HostFloat(42);
     let float2 = new HostFloat(55);
 
     strictEqual(instance.add(float1, float2).value, 42 + 1 + 3 + 55 + 1 + 3 + 5 + 1);
 
-    let float3 = new Float(22);
+    let float3 = new MyFloat(22);
 
     strictEqual(float3.get(), 22 + 1 + 2 + 4 + 3);
 
-    let result = Float.add(float3, 7);
+    let result = MyFloat.add(float3, 7);
 
     strictEqual(result.get(), 22 + 1 + 2 + 7 + 6 + 2 + 4 + 5 + 1 + 2 + 4 + 3);
 }

--- a/test/cases/resource-floats/world.wit
+++ b/test/cases/resource-floats/world.wit
@@ -1,30 +1,30 @@
 package test:test;
 
 interface resource-floats {
-  resource float {
+  resource my-float {
     constructor(v: f64);
     get: func() -> f64;
   }
 }
 
 world test {
-  use resource-floats.{float};
+  use resource-floats.{my-float};
 
   export resource-floats-exports: interface {
-    resource float {
+    resource my-float {
       constructor(v: f64);
       get: func() -> f64;
-      add: static func(a: float, b: f64) -> float;
+      add: static func(a: my-float, b: f64) -> my-float;
     }
   }
 
   import resource-floats-imports: interface {
-    resource float {
+    resource my-float {
       constructor(v: f64);
       get: func() -> f64;
-      add: static func(a: float, b: f64) -> float;
+      add: static func(a: my-float, b: f64) -> my-float;
     }
   }
 
-  export add: func(a: borrow<float>, b: borrow<float>) -> own<float>;
+  export add: func(a: borrow<my-float>, b: borrow<my-float>) -> own<my-float>;
 }


### PR DESCRIPTION
This fixes a bug where resource imports and exports were not using kebab case in the component model ABI, resulting in failures for resource names of more than one word.

Resolves https://github.com/bytecodealliance/ComponentizeJS/issues/145.