### PR TITLE
set timeOrigin in componentize_initialize

### DIFF
--- a/embedding/embedding.cpp
+++ b/embedding/embedding.cpp
@@ -361,6 +361,7 @@ componentize_initialize() {
     Runtime.clocks = true;
   }
 
+  builtins::web::performance::Performance::timeOrigin = std::chrono::steady_clock::now();
   __wizer_initialize();
   char env_name[100];
   LOG("(wizer) retrieve and generate the export bindings");


### PR DESCRIPTION
This workaround still works for me for #153. Same as first commit from #146.