### PR TITLE
Handle undefined `opts` and allow undefined `env`

### DIFF
--- a/src/componentize.js
+++ b/src/componentize.js
@@ -37,6 +37,7 @@ export async function componentize(jsSource, witWorld, opts) {
     opts = witWorld;
     witWorld = opts?.witWorld;
   }
+  opts = opts || {};
   const {
     sourceName = 'source.js',
     preview2Adapter = preview1AdapterReactorPath(),
@@ -45,7 +46,7 @@ export async function componentize(jsSource, witWorld, opts) {
     disableFeatures = [],
     enableFeatures = [],
     aotCache = fileURLToPath(new URL(`../lib/starlingmonkey_ics.wevalcache`, import.meta.url))
-  } = opts || {};
+  } = opts;
 
   const engine = opts.engine || fileURLToPath(
     new URL(opts.enableAot ? `../lib/starlingmonkey_embedding_weval.wasm` : `../lib/starlingmonkey_embedding${DEBUG_BUILD ? '.debug' : ''}.wasm`, import.meta.url));

--- a/types.d.ts
+++ b/types.d.ts
@@ -44,11 +44,11 @@ interface ComponentizeOptions {
    */
   enableFeatures?: [],
   /**
-   * Pass environment variables to the spawned Wizer or Weval Process If set to
-   * true, all host environment variables are passed. To pass only a subset,
-   * provide an object with the desired variables.   
+   * Pass environment variables to the spawned Wizer or Weval Process
+   * If set to true, all host environment variables are passed
+   * To pass only a subset, provide an object with the desired variables
    */
-  env: boolean | Record<string, string>,
+  env?: boolean | Record<string, string>,
 }
 
 /**


### PR DESCRIPTION
[This example](https://github.com/bytecodealliance/ComponentizeJS/blob/main/EXAMPLE.md) doesn’t currently work as the the code in [componentize.js](https://github.com/bytecodealliance/ComponentizeJS/blob/main/src/componentize.js) fails on this line https://github.com/bytecodealliance/ComponentizeJS/blob/d4ae59c16c0c5a781f3c4c18a4410a5fcf4e73a0/src/componentize.js#L50 because it can’t handle an undefined `opts`, even tho this should be allowed as suggested here https://github.com/bytecodealliance/ComponentizeJS/blob/d4ae59c16c0c5a781f3c4c18a4410a5fcf4e73a0/types.d.ts#L65 This PR should fix this.

I also allow the `env` field of `ComponentizeOptions` to be optional like all the others.
