### PR TITLE
feat: enable use of preexisting weval binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Build ComponentizeJS
         if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
         run: |
+          npm run clean
           npm run build
 
       - uses: actions/upload-artifact@v4
@@ -199,6 +200,7 @@ jobs:
       - name: Build Weval
         if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
         run: |
+          npm run clean
           npm run build:weval
 
       - uses: actions/upload-artifact@v4
@@ -244,19 +246,22 @@ jobs:
             lib/spidermonkey-embedding-splicer.js
             target
 
-      - name: Restore StarlingMonkey from cache
+      - name: Restore StarlingMonkey build from cache
         uses: actions/cache/restore@v4
-        id: starlingmonkey-jit
+        id: restore-starlingmonkey-jit-build
         with:
           key: output-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding.wasm
-            target
+            build-release
 
       - uses: actions/download-artifact@v4
-        if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
+        if: steps.restore-starlingmonkey-jit-build.outputs.cache-hit != 'true'
         with:
           name: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          path: |
+            lib/starlingmonkey_embedding.wasm
+            build-release
 
       - uses: actions/setup-node@v4
         with:
@@ -308,20 +313,24 @@ jobs:
             lib/spidermonkey-embedding-splicer.js
             target
 
-      - name: Restore StarlingMonkey (Weval) from cache
+      - name: Restore StarlingMonkey AOT build from cache
         uses: actions/cache/restore@v4
-        id: starlingmonkey-aot
+        id: restore-starlingmonkey-aot-build
         with:
           key: output-starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding_weval.wasm
             lib/starlingmonkey_ics.wevalcache
-            target
+            build-release-weval
 
       - uses: actions/download-artifact@v4
-        if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
+        if: steps.restore-starlingmonkey-aot-build.outputs.cache-hit != 'true'
         with:
           name: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          path: |
+            lib/starlingmonkey_embedding_weval.wasm
+            lib/starlingmonkey_ics.wevalcache
+            build-release-weval
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,72 +16,331 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - name: Install Rust
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add rustfmt
+      - name: Format source code
+        run: cargo fmt -- --check
+
+  #########
+  # Build #
+  #########
+
+  build-splicer:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - { os: ubuntu-latest, build: "npm run build", test: "npm run test", cacheDirectory: "build-release", cacheKeySuffix: "", enableAot: "0"  }
-          - { os: ubuntu-latest, build: "npm run build:weval", test: "npm run test:weval", cacheDirectory: "build-release-weval", cacheKeySuffix: "-weval", enableAot: "1" }
-    runs-on: ${{ matrix.config.os }}
+        node-version:
+          - '22'
+          - latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
-    - name: Install Rust Toolchain
-      run: |
-        rustup toolchain install 1.77.1
-        rustup target add wasm32-wasi --toolchain 1.77.1
-        rustup target add wasm32-wasi
+      - name: Install Rust Toolchain
+        run: |
+          rustup toolchain install 1.77.1
+          rustup target add wasm32-wasi --toolchain 1.77.1
+          rustup target add wasm32-wasi
 
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '22'
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+        with:
+          node-version: ${{matrix.node-version}}
 
-    - name: Cache Rust dependencies
-      uses: actions/cache@v3
-      id: rust-build
-      with:
-        path: target
-        key: engine-build-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+      - name: Install NPM packages
+        run: npm install
 
-    - name: Install NPM packages
-      run: npm install
+      - name: Cache Splicer build
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        id: splicer-build
+        with:
+          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          path: |
+            lib/spidermonkey-embedding-splicer.core2.wasm
+            lib/spidermonkey-embedding-splicer.core.wasm
+            lib/spidermonkey-embedding-splicer.d.ts
+            lib/spidermonkey-embedding-splicer.js
+            target
 
-    - name: Get StarlingMonkey Commit
-      id: starlingmonkey-commit
-      run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
+      - name: Build splicer
+        if: steps.splicer-build.outputs.cache-hit != 'true'
+        run: |
+          make lib/spidermonkey-embedding-splicer.js
 
-    - name: Cache StarlingMonkey
-      uses: actions/cache@v3
-      id: starlingmonkey-build
-      with:
-        path: ${{matrix.config.cacheDirectory}} 
-        key: engine-build${{matrix.config.cacheKeySuffix}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-
-    - name: Build
-      run: ${{matrix.config.build}}
-    
-    - name: Test
-      run: ${{matrix.config.test}}
-
-    - name: Cache Example build
-      uses: actions/cache@v3
-      with:
-        path: example/target
-        key: engine-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
-
-    - name: Test Example
-      run: cd example && ENABLE_AOT=${{matrix.config.enableAot}} npm run build && ./test.sh
-
-  rustfmt:
-    name: Rustfmt
+  build-jit:
     runs-on: ubuntu-latest
+    needs:
+      - build-splicer
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - '22'
+          - latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add rustfmt
-    - name: Format source code
-      run: cargo fmt -- --check
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          submodules: recursive
+
+      - name: Get StarlingMonkey Commit
+        id: starlingmonkey-commit
+        run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust Toolchain
+        run: |
+          rustup toolchain install 1.77.1
+          rustup target add wasm32-wasi --toolchain 1.77.1
+          rustup target add wasm32-wasi
+
+      - name: Restore Embedding Splicer from cache
+        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        id: splicer-build
+        with:
+          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          path: |
+            lib/spidermonkey-embedding-splicer.core2.wasm
+            lib/spidermonkey-embedding-splicer.core.wasm
+            lib/spidermonkey-embedding-splicer.d.ts
+            lib/spidermonkey-embedding-splicer.js
+            target
+
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+        with:
+          node-version: ${{matrix.node-version}}
+
+      - name: Install NPM packages
+        run: npm install
+
+      - name: Cache StarlingMonkey
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        id: starlingmonkey-jit
+        with:
+          key: output-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          lookup-only: 'true'
+          path: |
+            lib/starlingmonkey_embedding.wasm
+            build-release
+
+      - name: Build ComponentizeJS
+        if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
+        run: |
+          make release
+          make lib/starlingmonkey_embedding.wasm
+
+      - uses: actions/upload-artifact@v4
+        if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
+        with:
+          name: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          if-no-files-found: 'error'
+          path: |
+            lib/starlingmonkey_embedding.wasm
+            build-release
+
+  build-aot:
+    runs-on: ubuntu-latest
+    needs:
+      - build-splicer
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - '22'
+          - latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          submodules: recursive
+
+      - name: Get StarlingMonkey Commit
+        id: starlingmonkey-commit
+        run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust Toolchain
+        run: |
+          rustup toolchain install 1.77.1
+          rustup target add wasm32-wasi --toolchain 1.77.1
+          rustup target add wasm32-wasi
+
+      - name: Restore Embedding Splicer from cache
+        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        id: splicer-build
+        with:
+          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          path: |
+            lib/spidermonkey-embedding-splicer.core2.wasm
+            lib/spidermonkey-embedding-splicer.core.wasm
+            lib/spidermonkey-embedding-splicer.d.ts
+            lib/spidermonkey-embedding-splicer.js
+            target
+
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+        with:
+          node-version: ${{matrix.node-version}}
+
+      - name: Install NPM packages
+        run: npm install
+
+      - name: Cache StarlingMonkey (Weval)
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        id: starlingmonkey-aot
+        with:
+          key: output-starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          lookup-only: 'true'
+          path: |
+            lib/starlingmonkey_embedding_weval.wasm
+            lib/starlingmonkey_ics.wevalcache
+            build-release-weval
+
+      - name: Build Weval
+        if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
+        run: |
+          make release-weval
+          make lib/starlingmonkey_embedding_weval.wasm
+          make lib/starlingmonkey_ics.wevalcache
+
+      - uses: actions/upload-artifact@v4
+        if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
+        with:
+          name: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          if-no-files-found: 'error'
+          path: |
+            lib/starlingmonkey_embedding_weval.wasm
+            lib/starlingmonkey_ics.wevalcache
+            build-release-weval
+
+  ########
+  # Test #
+  ########
+
+  test-jit:
+    runs-on: ubuntu-latest
+    needs:
+      - build-jit
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - '22'
+          - latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - name: Get StarlingMonkey Commit
+        id: starlingmonkey-commit
+        run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Embedding Splicer from cache
+        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        id: splicer-build
+        with:
+          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          path: |
+            lib/spidermonkey-embedding-splicer.core2.wasm
+            lib/spidermonkey-embedding-splicer.core.wasm
+            lib/spidermonkey-embedding-splicer.d.ts
+            lib/spidermonkey-embedding-splicer.js
+            target
+
+      - name: Restore StarlingMonkey from cache
+        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        id: starlingmonkey-jit
+        with:
+          key: output-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          path: |
+            lib/starlingmonkey_embedding.wasm
+            target
+
+      - uses: actions/download-artifact@v4
+        if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
+        with:
+          name: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+        with:
+          node-version: ${{matrix.node-version}}
+
+      - name: Install NPM packages
+        run: npm install
+
+      - name: Test
+        run: npm run test
+
+      - name: Cache Example build
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        with:
+          path: example/target
+          key: output-example-jit-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
+
+      - name: Test Example
+        run: cd example && npm run build && ./test.sh
+
+  test-aot:
+    runs-on: ubuntu-latest
+    needs:
+      - build-aot
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - '22'
+          - latest
+    env:
+      ENABLE_AOT: "1"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - name: Get StarlingMonkey Commit
+        id: starlingmonkey-commit
+        run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Embedding Splicer from cache
+        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        id: splicer-build
+        with:
+          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          path: |
+            lib/spidermonkey-embedding-splicer.core2.wasm
+            lib/spidermonkey-embedding-splicer.core.wasm
+            lib/spidermonkey-embedding-splicer.d.ts
+            lib/spidermonkey-embedding-splicer.js
+            target
+
+      - name: Restore StarlingMonkey (Weval) from cache
+        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        id: starlingmonkey-aot
+        with:
+          key: output-starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          path: |
+            lib/starlingmonkey_embedding_weval.wasm
+            lib/starlingmonkey_ics.wevalcache
+            target
+
+      - uses: actions/download-artifact@v4
+        if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
+        with:
+          name: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+        with:
+          node-version: ${{matrix.node-version}}
+
+      - name: Install NPM packages
+        run: npm install
+
+      - name: Test
+        run: npm run test:weval
+
+      - name: Cache Example build
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        with:
+          path: example/target
+          key: output-example-aot-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
+
+      - name: Test Example
+        run: cd example && npm run build && ./test.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,8 +130,7 @@ jobs:
       - name: Build ComponentizeJS
         if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
         run: |
-          make release
-          make lib/starlingmonkey_embedding.wasm
+          npm run build
 
       - uses: actions/upload-artifact@v4
         if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
@@ -200,9 +199,7 @@ jobs:
       - name: Build Weval
         if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
         run: |
-          make release-weval
-          make lib/starlingmonkey_embedding_weval.wasm
-          make lib/starlingmonkey_ics.wevalcache
+          npm run build:weval
 
       - uses: actions/upload-artifact@v4
         if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: actions/checkout@v4
       - name: Install Rust
         run: |
           rustup update stable
@@ -41,7 +41,7 @@ jobs:
           - '22'
           - latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
         run: |
@@ -49,7 +49,7 @@ jobs:
           rustup target add wasm32-wasi --toolchain 1.77.1
           rustup target add wasm32-wasi
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
 
@@ -57,7 +57,7 @@ jobs:
         run: npm install
 
       - name: Cache Splicer build
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache@v4
         id: splicer-build
         with:
           key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
@@ -84,7 +84,7 @@ jobs:
           - '22'
           - latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -99,7 +99,7 @@ jobs:
           rustup target add wasm32-wasi
 
       - name: Restore Embedding Splicer from cache
-        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache/restore@v4
         id: splicer-build
         with:
           key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
@@ -110,7 +110,7 @@ jobs:
             lib/spidermonkey-embedding-splicer.js
             target
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
 
@@ -118,7 +118,7 @@ jobs:
         run: npm install
 
       - name: Cache StarlingMonkey
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache@v4
         id: starlingmonkey-jit
         with:
           key: output-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
@@ -152,7 +152,7 @@ jobs:
           - '22'
           - latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -167,7 +167,7 @@ jobs:
           rustup target add wasm32-wasi
 
       - name: Restore Embedding Splicer from cache
-        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache/restore@v4
         id: splicer-build
         with:
           key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
@@ -178,7 +178,7 @@ jobs:
             lib/spidermonkey-embedding-splicer.js
             target
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
 
@@ -186,7 +186,7 @@ jobs:
         run: npm install
 
       - name: Cache StarlingMonkey (Weval)
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache@v4
         id: starlingmonkey-aot
         with:
           key: output-starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
@@ -226,14 +226,14 @@ jobs:
           - '22'
           - latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: actions/checkout@v4
 
       - name: Get StarlingMonkey Commit
         id: starlingmonkey-commit
         run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
 
       - name: Restore Embedding Splicer from cache
-        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache/restore@v4
         id: splicer-build
         with:
           key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
@@ -245,7 +245,7 @@ jobs:
             target
 
       - name: Restore StarlingMonkey from cache
-        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache/restore@v4
         id: starlingmonkey-jit
         with:
           key: output-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
@@ -258,7 +258,7 @@ jobs:
         with:
           name: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
 
@@ -290,14 +290,14 @@ jobs:
     env:
       ENABLE_AOT: "1"
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: actions/checkout@v4
 
       - name: Get StarlingMonkey Commit
         id: starlingmonkey-commit
         run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
 
       - name: Restore Embedding Splicer from cache
-        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache/restore@v4
         id: splicer-build
         with:
           key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
@@ -309,7 +309,7 @@ jobs:
             target
 
       - name: Restore StarlingMonkey (Weval) from cache
-        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache/restore@v4
         id: starlingmonkey-aot
         with:
           key: output-starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
@@ -323,7 +323,7 @@ jobs:
         with:
           name: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # 4.1.0
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
 
@@ -334,7 +334,7 @@ jobs:
         run: npm run test:weval
 
       - name: Cache Example build
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache@v4
         with:
           path: example/target
           key: output-example-aot-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}

--- a/README.md
+++ b/README.md
@@ -108,7 +108,13 @@ The component iself can be executed in any component runtime, see the [example](
 
 ### AOT Compilation
 
-To enable AOT compilation, set the `enableAot: true` option to run [Weval](https://github.com/cfallin/weval) ahead-of-time compilation.
+To enable AOT compilation, set the `enableAot: true` option to run [Weval][weval] ahead-of-time compilation.
+
+[weval]: https://github.com/bytecodealliance/weval
+
+### Custom `weval` binary
+
+To use a custom (pre-downloaded) [`weval`][weval] binary, set the `wevalBin` option to the path to your desired weval binary.
 
 ### Async Support
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ npm run build
 npm run test
 ```
 
+Before being able to use `componetize-js` (ex. via `npm link`, from `jco`), you'll need to run:
+
+```
+npm run build:weval
+```
+
+This will produce a few files, most importantly `lib/starlingmonkey_embedding_weval.wasm`.
+
 To clean up a local installation (i.e. remove the installation of StarlingMonkey):
 
 ```console

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const { component } = await componentize(`
     log: func(msg: string);
   }
   world hello {
-    import logger; 
+    import logger;
     export say-hello: func(name: string);
   }
 `);
@@ -162,7 +162,7 @@ Note that features explicitly imported by the target world cannot be disabled - 
 
 ## Using StarlingMonkey's `fetch-event`
 
-The StarlingMonkey engine provides the ability to use `fetchEvent` to handle calls to `wasi:http/incoming-handler@0.2.0#handle`. When targeting worlds that export `wasi:http/incoming-handler@0.2.0` the fetch event will automatically be attached. Alternatively, to override the fetch event with a custom handler, export an explict `incomingHandler` or `'wasi:http/incoming-handler@0.2.0'` object. Using the `fetchEvent` requires enabling the `http` feature. 
+The StarlingMonkey engine provides the ability to use `fetchEvent` to handle calls to `wasi:http/incoming-handler@0.2.0#handle`. When targeting worlds that export `wasi:http/incoming-handler@0.2.0` the fetch event will automatically be attached. Alternatively, to override the fetch event with a custom handler, export an explict `incomingHandler` or `'wasi:http/incoming-handler@0.2.0'` object. Using the `fetchEvent` requires enabling the `http` feature.
 
 ## API
 
@@ -200,7 +200,19 @@ imports. Direct component analysis should be used to correctly infer the real im
 
 ### Building and testing
 
-Building and testing is based on a `npm install && npm run build && npm run test` workflow.
+Building and testing the project can be performed via NPM scripts (see [`package.json`](./package.json)):
+
+```console
+npm install
+npm run build
+npm run test
+```
+
+To clean up a local installation (i.e. remove the installation of StarlingMonkey):
+
+```console
+npm run clean
+```
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "types": "types.d.ts",
   "scripts": {
+    "clean": "npm run clean:starlingmonkey",
+    "clean:starlingmonkey": "rm -rf build-release",
     "build": "make release",
     "build:weval": "make release-weval",
     "build:debug": "make debug",

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -9,7 +9,7 @@ import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { resolve, join, dirname } from 'node:path';
 import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
-import { rmSync } from 'node:fs';
+import { rmSync, existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import {
   spliceBindings,
@@ -196,7 +196,13 @@ export async function componentize(jsSource, witWorld, opts) {
     console.log(env);
   }
   if (opts.enableAot) {
-    const wevalBin = await getWeval();
+    // Determine the weval bin path, possibly using a pre-downloaded version
+    let wevalBin;
+    if (opts.wevalBin && existsSync(opts.wevalBin)) {
+      wevalBin = opts.wevalBin;
+    } else {
+      wevalBin = await getWeval();
+    }
 
     try {
       let wevalProcess = spawnSync(

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,6 +16,10 @@ interface ComponentizeOptions {
    */
   enableAot?: boolean,
   /**
+   * Use a pre-existing path to the `weval` binary, if present
+   */
+  wevalBin?: string,
+  /**
    * Path to custom Preview2 Adapter
    */
   preview2Adapter?: string,


### PR DESCRIPTION
This commit enables using a pre-existing `weval` binary -- this is mostly to try to avoid some flaky tests in `jco` downstream, but this is probably a reasonable thing to have in general. 

I also shuffled around some instructions/docs while I was in there.