### PR TITLE
fix: specifier mappings in ComponentizeJS

### DIFF
--- a/src/componentize.js
+++ b/src/componentize.js
@@ -134,6 +134,10 @@ export async function componentize(jsSource, witWorld, opts) {
     curIdx = 0;
   for (const jsImpt of jsImports) {
     if (jsImpt.t !== 1 && jsImpt.t !== 2) continue;
+    if (!jsImpt.n) continue;
+    if (!imports.some(([impt]) => jsImpt.n === impt)) {
+      throw new Error(`Import '${jsImpt.n}' is not defined by the WIT world. Make sure to use a bundler for JS dependencies such as esbuild or RollupJS. Future ComponentizeJS versions may include Node.js builtins and bundling.`);
+    }
     const specifier = jsSource.slice(jsImpt.s, jsImpt.e);
     source += jsSource.slice(curIdx, jsImpt.s);
     source += `./${specifier.replace(':', '__').replace('/', '$')}.js`;

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -144,7 +144,7 @@ export async function componentize(jsSource, witWorld, opts) {
   // rewrite the JS source import specifiers to reference import wrappers
   let source = '',
     curIdx = 0;
-  const importSpecifiers = new Set([...imports.map(([impt]) => impt)]);
+  const importSpecifiers = new Set([...importWrappers.map(([impt]) => impt)]);
   for (const jsImpt of jsImports) {
     if (jsImpt.t !== 1 && jsImpt.t !== 2) continue;
     if (!jsImpt.n) continue;

--- a/test/cases/bad-binding/source.js
+++ b/test/cases/bad-binding/source.js
@@ -1,0 +1,1 @@
+import blah from 'not:world-defined';

--- a/test/cases/bad-binding/test.js
+++ b/test/cases/bad-binding/test.js
@@ -1,5 +1,5 @@
 import { strictEqual } from 'node:assert';
 
 export function err (error) {
-  strictEqual(error.message, "Import 'not:world-defined' is not defined by the WIT world. Make sure to use a bundler for JS dependencies such as esbuild or RollupJS. Future ComponentizeJS versions may include Node.js builtins and bundling.");
+  strictEqual(error.message, "Import 'not:world-defined' is not defined by the WIT world. Available imports are: 'local:char/chars'.\nMake sure to use a bundler for JS dependencies such as esbuild or RollupJS.");
 }

--- a/test/cases/bad-binding/test.js
+++ b/test/cases/bad-binding/test.js
@@ -1,0 +1,5 @@
+import { strictEqual } from 'node:assert';
+
+export function err (error) {
+  strictEqual(error.message, "Import 'not:world-defined' is not defined by the WIT world. Make sure to use a bundler for JS dependencies such as esbuild or RollupJS. Future ComponentizeJS versions may include Node.js builtins and bundling.");
+}

--- a/test/cases/bad-binding/world.wit
+++ b/test/cases/bad-binding/world.wit
@@ -1,0 +1,12 @@
+package local:%char;
+
+interface chars {
+  /// A function that returns a character
+  return-char: func() -> char;
+  /// A function that accepts a character
+  take-char: func(x: char);
+}
+
+world the-world {
+  import chars;
+}


### PR DESCRIPTION
This fixes an issue where we would incorrectly try to map `import.meta.url` due to not checking the import type.

Resolves https://github.com/bytecodealliance/ComponentizeJS/issues/164.