### PR TITLE
fix: invalid usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const { component } = await componentize(`
   import { log } from 'local:hello/logger';
 
   export function sayHello (name) {
-    log(`Hello ${name}`);
+    log(\`Hello \${name}\`);
   }
 
 `, `


### PR DESCRIPTION
It seems minor but I think it would be great if just copy-and-paste works.