### PR TITLE
Support passing arguments to the StarlingMonkey runtime

### DIFF
--- a/src/componentize.js
+++ b/src/componentize.js
@@ -50,6 +50,7 @@ export async function componentize(jsSource, witWorld, opts) {
       new URL(`../lib/starlingmonkey_ics.wevalcache`, import.meta.url)
     ),
   } = opts;
+  let runtimeArgs = opts.runtimeArgs;
 
   const engine =
     opts.engine ||
@@ -222,6 +223,10 @@ export async function componentize(jsSource, witWorld, opts) {
     console.log('--- Wizer Env ---');
     console.log(env);
   }
+
+  let sourcePath = maybeWindowsPath(join(sourceDir, sourceName.slice(0, -3) + '.bindings.js'));
+  runtimeArgs = runtimeArgs ? `${runtimeArgs} ${sourcePath}` : sourcePath;
+
   if (opts.enableAot) {
     // Determine the weval bin path, possibly using a pre-downloaded version
     let wevalBin;
@@ -247,9 +252,7 @@ export async function componentize(jsSource, witWorld, opts) {
         {
           stdio: [null, stdout, stderr],
           env,
-          input: maybeWindowsPath(
-            join(sourceDir, sourceName.slice(0, -3) + '.bindings.js')
-          ),
+          input: runtimeArgs,
           shell: true,
           encoding: 'utf-8',
         }
@@ -284,9 +287,7 @@ export async function componentize(jsSource, witWorld, opts) {
         {
           stdio: [null, stdout, stderr],
           env,
-          input: maybeWindowsPath(
-            join(sourceDir, sourceName.slice(0, -3) + '.bindings.js')
-          ),
+          input: runtimeArgs,
           shell: true,
           encoding: 'utf-8',
         }

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -39,18 +39,18 @@ export async function componentize(jsSource, witWorld, opts) {
     witWorld = opts?.witWorld;
   }
   opts = opts || {};
-  const {
+  let {
     sourceName = 'source.js',
     preview2Adapter = preview1AdapterReactorPath(),
     witPath,
     worldName,
     disableFeatures = [],
     enableFeatures = [],
+    runtimeArgs,
     aotCache = fileURLToPath(
       new URL(`../lib/starlingmonkey_ics.wevalcache`, import.meta.url)
     ),
   } = opts;
-  let runtimeArgs = opts.runtimeArgs;
 
   const engine =
     opts.engine ||

--- a/types.d.ts
+++ b/types.d.ts
@@ -53,6 +53,11 @@ interface ComponentizeOptions {
    * To pass only a subset, provide an object with the desired variables
    */
   env?: boolean | Record<string, string>,
+  /**
+   * Runtime arguments to provide to the StarlingMonkey engine initialization
+   * (see https://github.com/bytecodealliance/StarlingMonkey/blob/main/include/config-parser.h)
+   */
+  runtimeArgs?: string,
 }
 
 /**


### PR DESCRIPTION
StarlingMonkey supports a growing number of arguments in addition to the filename of the script to run. This commit adds support for passing those arguments through when componentizing.

I think it'll eventually make sense to expose some of these arguments more explicitly, but providing this option allows us to evolve the interfaces separately, similar to how e.g. clang supports passing linker arguments, or cargo supports passing rustc arguments.