### PR TITLE
Remove warning about stubbed imports

### DIFF
--- a/crates/spidermonkey-embedding-splicer/src/stub_wasi.rs
+++ b/crates/spidermonkey-embedding-splicer/src/stub_wasi.rs
@@ -48,7 +48,6 @@ where
         let mut builder = FunctionBuilder::new(params.as_slice(), results.as_slice());
         let _args = stub(&mut builder)?;
 
-        println!("Warning: the component import '{full_import}#{name}' isn't listed in the target WIT world, and will abort execution when called.");
         builder.replace_import_in_module(module, iid);
 
         return Ok(Some(fid));


### PR DESCRIPTION
The warning added in #185 turns out to be too noisy: there are too many situations in which an import exists, but should be stubbed. In particular once StarlingMonkey is updated to include https://github.com/bytecodealliance/StarlingMonkey/pull/218, the warning would essentially be shown for every component, because in most cases, the target world won't contain the necessary interfaces, by design.