### PR TITLE
feat: support the debugBuild option for debugging Wasm stacks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Cache Example build
         uses: actions/cache@v4
         with:
-          path: example/target
+          path: examples/target
           key: example-jit-cargo-${{ hashFiles('examples/src/main.rs', 'examples/Cargo.lock', 'examples/hello.wit') }}
 
       - name: Test Example

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/cache@v4
         id: starlingmonkey-jit
         with:
-          key: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: key-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           lookup-only: 'true'
           path: |
             lib/starlingmonkey_embedding.wasm
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
         with:
-          name: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          name: key-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           if-no-files-found: 'error'
           path: |
             lib/starlingmonkey_embedding.wasm
@@ -259,7 +259,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: restore-starlingmonkey-jit-build
         with:
-          key: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: key-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding.wasm
             build-release
@@ -267,7 +267,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: steps.restore-starlingmonkey-jit-build.outputs.cache-hit != 'true'
         with:
-          name: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          name: key-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding.wasm
             build-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: restore-starlingmonkey-jit-build
         with:
-          key: starlingmonkey-${{matrix-build-type}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: starlingmonkey-${{matrix.build-type}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: lib
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,12 +34,6 @@ jobs:
 
   build-splicer:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - '22.11.0'
-          # - latest reenable when https://github.com/nodejs/node/issues/57172 is fixed
     steps:
       - uses: actions/checkout@v4
 
@@ -51,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{matrix.node-version}}
+          node-version: '22'
 
       - name: Install NPM packages
         run: npm install
@@ -60,7 +54,7 @@ jobs:
         uses: actions/cache@v4
         id: splicer-build
         with:
-          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          key: splicer-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
           path: |
             lib/spidermonkey-embedding-splicer.core2.wasm
             lib/spidermonkey-embedding-splicer.core.wasm
@@ -69,19 +63,19 @@ jobs:
 
       - name: Build splicer
         if: steps.splicer-build.outputs.cache-hit != 'true'
-        run: |
-          make lib/spidermonkey-embedding-splicer.js
+        run: make lib/spidermonkey-embedding-splicer.js
 
-  build-jit:
+  build:
     runs-on: ubuntu-latest
     needs:
       - build-splicer
     strategy:
       fail-fast: false
       matrix:
-        node-version:
-          - '22'
-          - latest
+        build-type:
+          - 'release'
+          - 'debug'
+          - 'weval'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,12 +98,12 @@ jobs:
         uses: actions/cache/restore@v4
         id: splicer-build
         with:
-          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          key: splicer-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
           path: lib
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{matrix.node-version}}
+          node-version: '22'
 
       - name: Install NPM packages
         run: npm install
@@ -117,74 +111,31 @@ jobs:
       - name: Build ComponentizeJS
         run: |
           npm run clean
-          npm run build:debug
-          npm run build:release
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-          if-no-files-found: 'error'
-          path: lib
-
-  build-aot:
-    runs-on: ubuntu-latest
-    needs:
-      - build-splicer
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - '22'
-          - latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Get StarlingMonkey Commit
-        id: starlingmonkey-commit
-        run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
-
-      - name: Install Rust Toolchain
-        run: |
-          rustup toolchain install 1.77.1
-          rustup target add wasm32-wasi --toolchain 1.77.1
-          rustup target add wasm32-wasip1
-
-      - name: Install wasm-tools
-        run: cargo install wasm-tools
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{matrix.node-version}}
-
-      - name: Install NPM packages
-        run: npm install
-
-      - name: Build Weval
-        run: |
-          npm run clean
-          npm run build:weval
+          npm run build:${{matrix.build-type}}
 
       - uses: actions/cache/save@v4
         with:
-          key: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: starlingmonkey-${{matrix.build-type}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: lib
 
   ########
   # Test #
   ########
 
-  test-jit:
+  test:
     runs-on: ubuntu-latest
     needs:
-      - build-jit
+      - build
     strategy:
       fail-fast: false
       matrix:
         node-version:
           - '22'
-          - latest
+          # - latest reenable when https://github.com/nodejs/node/issues/57172 is fixed
+        build-type:
+          - 'release'
+          - 'debug'
+          - 'weval'
     steps:
       - uses: actions/checkout@v4
 
@@ -196,7 +147,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: restore-starlingmonkey-jit-build
         with:
-          key: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: starlingmonkey-${{matrix-build-type}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: lib
 
       - uses: actions/setup-node@v4
@@ -207,10 +158,10 @@ jobs:
         run: npm install
 
       - name: Test
-        run: npm run test
+        run: npm run test:${{matrix.build-type}}
 
       - name: Cache Example build
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
+        uses: actions/cache@v4
         with:
           path: example/target
           key: example-jit-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
@@ -222,7 +173,7 @@ jobs:
   test-aot:
     runs-on: ubuntu-latest
     needs:
-      - build-aot
+      - build
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,8 @@ jobs:
         if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
         run: |
           npm run clean
-          npm run build
+          npm run build:debug
+          npm run build:release
 
       - uses: actions/upload-artifact@v4
         if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
@@ -201,6 +202,7 @@ jobs:
         if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
         run: |
           npm run clean
+          npm run build:debug
           npm run build:weval
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,6 @@ jobs:
             lib/spidermonkey-embedding-splicer.core.wasm
             lib/spidermonkey-embedding-splicer.d.ts
             lib/spidermonkey-embedding-splicer.js
-            target
 
       - name: Build splicer
         if: steps.splicer-build.outputs.cache-hit != 'true'
@@ -106,12 +105,7 @@ jobs:
         id: splicer-build
         with:
           key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
-          path: |
-            lib/spidermonkey-embedding-splicer.core2.wasm
-            lib/spidermonkey-embedding-splicer.core.wasm
-            lib/spidermonkey-embedding-splicer.d.ts
-            lib/spidermonkey-embedding-splicer.js
-            target
+          path: lib
 
       - uses: actions/setup-node@v4
         with:
@@ -120,33 +114,17 @@ jobs:
       - name: Install NPM packages
         run: npm install
 
-      - name: Cache StarlingMonkey
-        uses: actions/cache@v4
-        id: starlingmonkey-jit
-        with:
-          key: key-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-          lookup-only: 'true'
-          path: |
-            lib/starlingmonkey_embedding.wasm
-            lib/starlingmonkey_embedding.debug.wasm
-            build-release
-
       - name: Build ComponentizeJS
-        if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
         run: |
           npm run clean
           npm run build:debug
           npm run build:release
 
       - uses: actions/upload-artifact@v4
-        if: steps.starlingmonkey-jit.outputs.cache-hit != 'true'
         with:
-          name: key-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          name: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           if-no-files-found: 'error'
-          path: |
-            lib/starlingmonkey_embedding.wasm
-            lib/starlingmonkey_embedding.debug.wasm
-            build-release
+          path: lib
 
   build-aot:
     runs-on: ubuntu-latest
@@ -176,18 +154,6 @@ jobs:
       - name: Install wasm-tools
         run: cargo install wasm-tools
 
-      - name: Restore Embedding Splicer from cache
-        uses: actions/cache/restore@v4
-        id: splicer-build
-        with:
-          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
-          path: |
-            lib/spidermonkey-embedding-splicer.core2.wasm
-            lib/spidermonkey-embedding-splicer.core.wasm
-            lib/spidermonkey-embedding-splicer.d.ts
-            lib/spidermonkey-embedding-splicer.js
-            target
-
       - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
@@ -195,32 +161,15 @@ jobs:
       - name: Install NPM packages
         run: npm install
 
-      - name: Cache StarlingMonkey (Weval)
-        uses: actions/cache@v4
-        id: starlingmonkey-aot
-        with:
-          key: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-          lookup-only: 'true'
-          path: |
-            lib/starlingmonkey_embedding_weval.wasm
-            lib/starlingmonkey_ics.wevalcache
-            build-release-weval
-
       - name: Build Weval
-        if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
         run: |
           npm run clean
           npm run build:weval
 
-      - uses: actions/upload-artifact@v4
-        if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
+      - uses: actions/cache/save@v4
         with:
-          name: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-          if-no-files-found: 'error'
-          path: |
-            lib/starlingmonkey_embedding_weval.wasm
-            lib/starlingmonkey_ics.wevalcache
-            build-release-weval
+          key: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          path: lib
 
   ########
   # Test #
@@ -243,34 +192,12 @@ jobs:
         id: starlingmonkey-commit
         run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Embedding Splicer from cache
-        uses: actions/cache/restore@v4
-        id: splicer-build
-        with:
-          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
-          path: |
-            lib/spidermonkey-embedding-splicer.core2.wasm
-            lib/spidermonkey-embedding-splicer.core.wasm
-            lib/spidermonkey-embedding-splicer.d.ts
-            lib/spidermonkey-embedding-splicer.js
-            target
-
       - name: Restore StarlingMonkey build from cache
         uses: actions/cache/restore@v4
         id: restore-starlingmonkey-jit-build
         with:
-          key: key-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-          path: |
-            lib/starlingmonkey_embedding.wasm
-            build-release
-
-      - uses: actions/download-artifact@v4
-        if: steps.restore-starlingmonkey-jit-build.outputs.cache-hit != 'true'
-        with:
-          name: key-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-          path: |
-            lib/starlingmonkey_embedding.wasm
-            build-release
+          key: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          path: lib
 
       - uses: actions/setup-node@v4
         with:
@@ -311,36 +238,12 @@ jobs:
         id: starlingmonkey-commit
         run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Embedding Splicer from cache
-        uses: actions/cache/restore@v4
-        id: splicer-build
-        with:
-          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
-          path: |
-            lib/spidermonkey-embedding-splicer.core2.wasm
-            lib/spidermonkey-embedding-splicer.core.wasm
-            lib/spidermonkey-embedding-splicer.d.ts
-            lib/spidermonkey-embedding-splicer.js
-            target
-
       - name: Restore StarlingMonkey AOT build from cache
         uses: actions/cache/restore@v4
         id: restore-starlingmonkey-aot-build
         with:
           key: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-          path: |
-            lib/starlingmonkey_embedding_weval.wasm
-            lib/starlingmonkey_ics.wevalcache
-            build-release-weval
-
-      - uses: actions/download-artifact@v4
-        if: steps.restore-starlingmonkey-aot-build.outputs.cache-hit != 'true'
-        with:
-          name: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-          path: |
-            lib/starlingmonkey_embedding_weval.wasm
-            lib/starlingmonkey_ics.wevalcache
-            build-release-weval
+          path: lib
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,5 +202,5 @@ jobs:
 
       - name: Test Example
         run: |
-          cd example/hello-world
+          cd examples/hello-world
           ./test.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,22 +166,10 @@ jobs:
           path: example/target
           key: example-jit-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
 
-      - name: Test Example
-        working-directory: examples/hello-world
-        run: bash test.sh
-
-  test-aot:
+  test-example:
     runs-on: ubuntu-latest
     needs:
       - build
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - '22'
-          - latest
-    env:
-      ENABLE_AOT: "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -189,29 +177,22 @@ jobs:
         id: starlingmonkey-commit
         run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
 
-      - name: Restore StarlingMonkey AOT build from cache
+      - name: Restore StarlingMonkey build from cache
         uses: actions/cache/restore@v4
-        id: restore-starlingmonkey-aot-build
+        id: restore-starlingmonkey-jit-build
         with:
-          key: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: starlingmonkey-release-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: lib
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{matrix.node-version}}
+          node-version: '22'
 
       - name: Install NPM packages
         run: npm install
-
-      - name: Test
-        run: npm run test:weval
 
       - name: Cache Example build
         uses: actions/cache@v4
         with:
           path: example/target
-          key: example-aot-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
-
-      - name: Test Example
-        working-directory: examples/hello-world
-        run: bash test.sh
+          key: example-jit-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v4
         id: splicer-build
         with:
-          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
           path: |
             lib/spidermonkey-embedding-splicer.core2.wasm
             lib/spidermonkey-embedding-splicer.core.wasm
@@ -102,7 +102,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: splicer-build
         with:
-          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
           path: |
             lib/spidermonkey-embedding-splicer.core2.wasm
             lib/spidermonkey-embedding-splicer.core.wasm
@@ -121,7 +121,7 @@ jobs:
         uses: actions/cache@v4
         id: starlingmonkey-jit
         with:
-          key: output-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           lookup-only: 'true'
           path: |
             lib/starlingmonkey_embedding.wasm
@@ -173,7 +173,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: splicer-build
         with:
-          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
           path: |
             lib/spidermonkey-embedding-splicer.core2.wasm
             lib/spidermonkey-embedding-splicer.core.wasm
@@ -192,7 +192,7 @@ jobs:
         uses: actions/cache@v4
         id: starlingmonkey-aot
         with:
-          key: output-starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           lookup-only: 'true'
           path: |
             lib/starlingmonkey_embedding_weval.wasm
@@ -242,7 +242,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: splicer-build
         with:
-          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
           path: |
             lib/spidermonkey-embedding-splicer.core2.wasm
             lib/spidermonkey-embedding-splicer.core.wasm
@@ -254,7 +254,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: restore-starlingmonkey-jit-build
         with:
-          key: output-starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: starlingmonkey-jit-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding.wasm
             build-release
@@ -281,7 +281,7 @@ jobs:
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # 4.1.2
         with:
           path: example/target
-          key: output-example-jit-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
+          key: example-jit-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
 
       - name: Test Example
         working-directory: examples/hello-world
@@ -310,7 +310,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: splicer-build
         with:
-          key: output-splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          key: splicer-node-${{matrix.node-version}}-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
           path: |
             lib/spidermonkey-embedding-splicer.core2.wasm
             lib/spidermonkey-embedding-splicer.core.wasm
@@ -322,7 +322,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: restore-starlingmonkey-aot-build
         with:
-          key: output-starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          key: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding_weval.wasm
             lib/starlingmonkey_embedding.debug.wasm
@@ -353,7 +353,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: example/target
-          key: output-example-aot-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
+          key: example-aot-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
 
       - name: Test Example
         working-directory: examples/hello-world

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,21 +35,6 @@ jobs:
   build-splicer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust Toolchain
-        run: |
-          rustup toolchain install 1.77.1
-          rustup target add wasm32-wasi --toolchain 1.77.1
-          rustup target add wasm32-wasip1
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Install NPM packages
-        run: npm install
-
       - name: Cache Splicer build
         uses: actions/cache@v4
         id: splicer-build
@@ -60,6 +45,25 @@ jobs:
             lib/spidermonkey-embedding-splicer.core.wasm
             lib/spidermonkey-embedding-splicer.d.ts
             lib/spidermonkey-embedding-splicer.js
+
+      - uses: actions/checkout@v4
+        if: steps.splicer-build.outputs.cache-hit != 'true'
+
+      - name: Install Rust Toolchain
+        if: steps.splicer-build.outputs.cache-hit != 'true'
+        run: |
+          rustup toolchain install 1.77.1
+          rustup target add wasm32-wasi --toolchain 1.77.1
+          rustup target add wasm32-wasip1
+
+      - uses: actions/setup-node@v4
+        if: steps.splicer-build.outputs.cache-hit != 'true'
+        with:
+          node-version: '22'
+
+      - name: Install NPM packages
+        if: steps.splicer-build.outputs.cache-hit != 'true'
+        run: npm install
 
       - name: Build splicer
         if: steps.splicer-build.outputs.cache-hit != 'true'
@@ -84,14 +88,22 @@ jobs:
       - name: Get StarlingMonkey Commit
         id: starlingmonkey-commit
         run: echo "STARLINGMONKEY_HASH=$(git submodule status | head -c9 | tail -c8)" >> "$GITHUB_OUTPUT"
+      
+      - uses: actions/cache@v4
+        id: starlingmonkey-build
+        with:
+          key: starlingmonkey-${{matrix.build-type}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
+          path: lib
 
       - name: Install Rust Toolchain
+        if: steps.starlingmonkey-build.outputs.cache-hit != 'true'
         run: |
           rustup toolchain install 1.77.1
           rustup target add wasm32-wasi --toolchain 1.77.1
           rustup target add wasm32-wasip1
 
       - name: Install wasm-tools
+        if: steps.starlingmonkey-build.outputs.cache-hit != 'true'
         run: cargo install wasm-tools
 
       - name: Restore Embedding Splicer from cache
@@ -102,21 +114,19 @@ jobs:
           path: lib
 
       - uses: actions/setup-node@v4
+        if: steps.starlingmonkey-build.outputs.cache-hit != 'true'
         with:
           node-version: '22'
 
       - name: Install NPM packages
+        if: steps.starlingmonkey-build.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Build ComponentizeJS
+        if: steps.starlingmonkey-build.outputs.cache-hit != 'true'
         run: |
           npm run clean
           npm run build:${{matrix.build-type}}
-
-      - uses: actions/cache/save@v4
-        with:
-          key: starlingmonkey-${{matrix.build-type}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
-          path: lib
 
   ########
   # Test #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - '22'
+          - '22.14.0'
           # - latest reenable when https://github.com/nodejs/node/issues/57172 is fixed
         build-type:
           - 'release'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - '22'
-          - latest
+          - '22.11.0'
+          # - latest reenable when https://github.com/nodejs/node/issues/57172 is fixed
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,8 @@ jobs:
   build-splicer:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Cache Splicer build
         uses: actions/cache@v4
         id: splicer-build
@@ -45,9 +47,6 @@ jobs:
             lib/spidermonkey-embedding-splicer.core.wasm
             lib/spidermonkey-embedding-splicer.d.ts
             lib/spidermonkey-embedding-splicer.js
-
-      - uses: actions/checkout@v4
-        if: steps.splicer-build.outputs.cache-hit != 'true'
 
       - name: Install Rust Toolchain
         if: steps.splicer-build.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,7 +209,6 @@ jobs:
         if: steps.starlingmonkey-aot.outputs.cache-hit != 'true'
         run: |
           npm run clean
-          npm run build:debug
           npm run build:weval
 
       - uses: actions/upload-artifact@v4
@@ -219,7 +218,6 @@ jobs:
           if-no-files-found: 'error'
           path: |
             lib/starlingmonkey_embedding_weval.wasm
-            lib/starlingmonkey_embedding.debug.wasm
             lib/starlingmonkey_ics.wevalcache
             build-release-weval
 
@@ -331,7 +329,6 @@ jobs:
           key: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding_weval.wasm
-            lib/starlingmonkey_embedding.debug.wasm
             lib/starlingmonkey_ics.wevalcache
             build-release-weval
 
@@ -341,7 +338,6 @@ jobs:
           name: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding_weval.wasm
-            lib/starlingmonkey_embedding.debug.wasm
             lib/starlingmonkey_ics.wevalcache
             build-release-weval
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,9 @@ jobs:
           rustup target add wasm32-wasi --toolchain 1.77.1
           rustup target add wasm32-wasip1
 
+      - name: Install wasm-tools
+        run: cargo install wasm-tools
+
       - name: Restore Embedding Splicer from cache
         uses: actions/cache/restore@v4
         id: splicer-build
@@ -168,6 +171,9 @@ jobs:
           rustup toolchain install 1.77.1
           rustup target add wasm32-wasi --toolchain 1.77.1
           rustup target add wasm32-wasip1
+
+      - name: Install wasm-tools
+        run: cargo install wasm-tools
 
       - name: Restore Embedding Splicer from cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,12 +169,6 @@ jobs:
       - name: Test
         run: npm run test:${{matrix.build-type}}
 
-      - name: Cache Example build
-        uses: actions/cache@v4
-        with:
-          path: example/target
-          key: example-jit-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
-
   test-example:
     runs-on: ubuntu-latest
     needs:
@@ -204,4 +198,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: example/target
-          key: example-jit-cargo-${{ hashFiles('example/src/main.rs', 'example/Cargo.lock', 'example/hello.wit') }}
+          key: example-jit-cargo-${{ hashFiles('examples/src/main.rs', 'examples/Cargo.lock', 'examples/hello.wit') }}
+
+      - name: Test Example
+        run: |
+          cd example/hello-world
+          ./test.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,7 @@ jobs:
         id: splicer-build
         with:
           key: splicer-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
-          path: |
-            lib/spidermonkey-embedding-splicer.core2.wasm
-            lib/spidermonkey-embedding-splicer.core.wasm
-            lib/spidermonkey-embedding-splicer.d.ts
-            lib/spidermonkey-embedding-splicer.js
+          path: lib
 
       - name: Install Rust Toolchain
         if: steps.splicer-build.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,6 +128,7 @@ jobs:
           lookup-only: 'true'
           path: |
             lib/starlingmonkey_embedding.wasm
+            lib/starlingmonkey_embedding.debug.wasm
             build-release
 
       - name: Build ComponentizeJS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,9 @@ jobs:
         id: splicer-build
         with:
           key: splicer-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
-          path: lib
+          path: |
+            lib
+            target
 
       - name: Install Rust Toolchain
         if: steps.splicer-build.outputs.cache-hit != 'true'
@@ -106,7 +108,9 @@ jobs:
         id: splicer-build
         with:
           key: splicer-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
-          path: lib
+          path: |
+            lib
+            target
 
       - uses: actions/setup-node@v4
         if: steps.starlingmonkey-build.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,6 +141,7 @@ jobs:
           if-no-files-found: 'error'
           path: |
             lib/starlingmonkey_embedding.wasm
+            lib/starlingmonkey_embedding.debug.wasm
             build-release
 
   build-aot:
@@ -212,6 +213,7 @@ jobs:
           if-no-files-found: 'error'
           path: |
             lib/starlingmonkey_embedding_weval.wasm
+            lib/starlingmonkey_embedding.debug.wasm
             lib/starlingmonkey_ics.wevalcache
             build-release-weval
 
@@ -323,6 +325,7 @@ jobs:
           key: output-starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding_weval.wasm
+            lib/starlingmonkey_embedding.debug.wasm
             lib/starlingmonkey_ics.wevalcache
             build-release-weval
 
@@ -332,6 +335,7 @@ jobs:
           name: starlingmonkey-aot-node-${{matrix.node-version}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: |
             lib/starlingmonkey_embedding_weval.wasm
+            lib/starlingmonkey_embedding.debug.wasm
             lib/starlingmonkey_ics.wevalcache
             build-release-weval
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lib/starlingmonkey_ics.wevalcache: lib/starlingmonkey_embedding_weval.wasm
 lib/starlingmonkey_embedding.debug.wasm: StarlingMonkey/cmake/* embedding/* StarlingMonkey/runtime/* StarlingMonkey/builtins/* StarlingMonkey/builtins/*/* StarlingMonkey/builtins/*/*/* StarlingMonkey/include/* | lib
 	cmake -B build-debug -DCMAKE_BUILD_TYPE=RelWithDebInfo
 	make -j16 -C build-debug
-	@cp build-debug/starling-raw.wasm/starling-raw.wasm $@
+	wasm-tools strip build-debug/starling-raw.wasm/starling-raw.wasm -d ".debug_(info|loc|ranges|abbrev|line|str)" -o $@
 
 obj:
 	mkdir -p obj

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ export function componentize(jsSource: string, opts: {
   witPath: string,
   worldName: string,
   debug?: bool,
+  debugBuild?: bool,
   sourceName?: string,
   engine?: string,
   preview2Adapter?: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@bytecodealliance/preview2-shim": "^0.17.1",
-        "mocha": "^10.2.0"
+        "mocha": "^11.1.0"
       }
     },
     "node_modules/@bytecodealliance/componentize-js": {
@@ -227,6 +227,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -592,15 +610,26 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.6.tgz",
-      "integrity": "sha512-z8YVS3XszxFTO73iwvFDNpQIzdMmSDTP/mB3E/ucR37V3Sx57hSExcXyMoNwaucWxnsWf4xfbZv0iZ30jr0M4Q==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.7.tgz",
+      "integrity": "sha512-5yximcFK5FNompXfJFoWanu5l8v1hNGqNHh9du1xETp9HWk/B/PzvchX55WYOPaIeNglG8++68AAiauBAtbnzw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.3.1",
         "@emnapi/runtime": "^1.3.1",
         "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -648,16 +677,13 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -935,15 +961,18 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/cliui/node_modules/ansi-regex": {
@@ -954,6 +983,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/cliui/node_modules/emoji-regex": {
@@ -991,6 +1036,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1025,6 +1088,21 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -1163,10 +1241,18 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -1265,18 +1351,28 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1329,21 +1425,21 @@
       }
     },
     "node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": ">=12"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1360,6 +1456,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/graceful-fs": {
@@ -1407,18 +1519,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -1538,6 +1638,29 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1584,6 +1707,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1613,6 +1752,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/make-dir": {
       "version": "1.3.0",
@@ -1660,6 +1806,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
@@ -1676,9 +1832,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
-      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
+      "integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1689,7 +1845,7 @@
         "diff": "^5.2.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
-        "glob": "^8.1.0",
+        "glob": "^10.4.5",
         "he": "^1.2.0",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
@@ -1699,8 +1855,8 @@
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
       },
       "bin": {
@@ -1708,7 +1864,7 @@
         "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/ms": {
@@ -1762,9 +1918,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.1.1.tgz",
-      "integrity": "sha512-YWielGi1XzG1UTvOaCFaNgEnuhZVMSHYkW/FQ7UX8O26PtlpdM84c0f7wLPlkvx2RfiQmnzd61d/MGxmpQeJPw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -1783,6 +1939,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
     },
     "node_modules/ora/node_modules/is-unicode-supported": {
       "version": "2.1.0",
@@ -1824,6 +1986,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -1856,6 +2035,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1864,6 +2050,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pend": {
@@ -2040,6 +2253,29 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2099,20 +2335,67 @@
       "license": "MIT"
     },
     "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -2128,6 +2411,30 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-dirs": {
@@ -2187,9 +2494,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -2258,6 +2565,22 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/workerpool": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
@@ -2266,6 +2589,25 @@
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -2283,7 +2625,7 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
@@ -2293,14 +2635,30 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/wrap-ansi/node_modules/string-width": {
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -2315,7 +2673,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -2354,32 +2712,32 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-unparser": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "clean": "npm run clean:starlingmonkey",
     "clean:starlingmonkey": "rm -rf build-release",
-    "build": "make release",
+    "build": "make release && make release-weval && make debug",
+    "build:release": "make release",
     "build:weval": "make release-weval",
     "build:debug": "make debug",
     "test": "mocha -u tdd test/test.js --timeout 120000",
@@ -33,6 +34,7 @@
     "lib/interfaces",
     "lib/spidermonkey-*",
     "lib/starlingmonkey_embedding.wasm",
+    "lib/starlingmonkey_embedding.debug.wasm",
     "lib/starlingmonkey_embedding_weval.wasm",
     "lib/starlingmonkey_ics.wevalcache",
     "src",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:weval": "make release-weval",
     "build:debug": "make debug",
     "test": "mocha -u tdd test/test.js --timeout 120000",
+    "test:release": "mocha -u tdd test/test.js --timeout 120000",
     "test:weval": "WEVAL_TEST=1 mocha -u tdd test/test.js --timeout 120000",
     "test:debug": "DEBUG_TEST=1 mocha -u tdd test/test.js --timeout 120000",
     "prepublishOnly": "npm run build"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:debug": "make debug",
     "test": "mocha -u tdd test/test.js --timeout 120000",
     "test:weval": "WEVAL_TEST=1 mocha -u tdd test/test.js --timeout 120000",
+    "test:debug": "DEBUG_TEST=1 mocha -u tdd test/test.js --timeout 120000",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@bytecodealliance/preview2-shim": "^0.17.1",
-    "mocha": "^10.2.0"
+    "mocha": "^11.1.0"
   },
   "dependencies": {
     "@bytecodealliance/jco": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "scripts": {
     "clean": "npm run clean:starlingmonkey",
     "clean:starlingmonkey": "rm -rf build-release",
-    "build": "make release && make release-weval && make debug",
+    "build": "npm run build:release && npm run build:debug && npm run build:weval",
     "build:release": "make release",
     "build:weval": "make release-weval",
     "build:debug": "make debug",
     "test": "mocha -u tdd test/test.js --timeout 120000",
     "test:weval": "WEVAL_TEST=1 mocha -u tdd test/test.js --timeout 120000",
-    "prepublishOnly": "npm run build && npm run build:weval"
+    "prepublishOnly": "npm run build"
   },
   "files": [
     "lib/interfaces",

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -24,7 +24,6 @@ export const { version } = JSON.parse(
 const isWindows = platform === 'win32';
 const DEBUG_BINDINGS = false;
 const DEBUG_CALLS = false;
-const DEBUG_BUILD = false;
 const DEBUG_BINARY = false;
 
 function maybeWindowsPath(path) {
@@ -46,6 +45,7 @@ export async function componentize(jsSource, witWorld, opts) {
     worldName,
     disableFeatures = [],
     enableFeatures = [],
+    debugBuild = false,
     runtimeArgs,
     aotCache = fileURLToPath(
       new URL(`../lib/starlingmonkey_ics.wevalcache`, import.meta.url)
@@ -59,7 +59,7 @@ export async function componentize(jsSource, witWorld, opts) {
         opts.enableAot
           ? `../lib/starlingmonkey_embedding_weval.wasm`
           : `../lib/starlingmonkey_embedding${
-              DEBUG_BUILD ? '.debug' : ''
+              debugBuild ? '.debug' : ''
             }.wasm`,
         import.meta.url
       )

--- a/test/builtins/performance.js
+++ b/test/builtins/performance.js
@@ -22,7 +22,7 @@ export async function test(run) {
   ok(stderr.includes(' ms'));
   const time = Number(stderr.split(' ms')[0]);
   // TODO: fix back to half a millisecond when Weval fix is added
-  if (time > 4) {
+  if (time > 5) {
     throw new Error('took more than half a millisecond - ' + time + ' ms');
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -40,6 +40,8 @@ suite('Builtins', () => {
       `,
         {
           sourceName: `${name}.js`,
+          // also test the debug build while we are about it
+          debugBuild: true,
           enableFeatures,
           disableFeatures: maybeLogging(disableFeatures),
           enableAot

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,9 @@ import { strictEqual } from 'node:assert';
 const DEBUG_TRACING = false;
 const LOG_DEBUGGING = false;
 
+const enableAot = process.env.WEVAL_TEST == '1';
+const debugBuild = process.env.DEBUG_TEST == '1';
+
 function maybeLogging(disableFeatures) {
   if (!LOG_DEBUGGING) return disableFeatures;
   if (disableFeatures && disableFeatures.includes('stdio')) {
@@ -18,8 +21,6 @@ function maybeLogging(disableFeatures) {
 
 const builtinsCases = await readdir(new URL('./builtins', import.meta.url));
 suite('Builtins', () => {
-  const enableAot = process.env.WEVAL_TEST == '1'
-
   for (const filename of builtinsCases) {
     const name = filename.slice(0, -3);
     test(name, async () => {
@@ -27,7 +28,7 @@ suite('Builtins', () => {
         source,
         test: runTest,
         disableFeatures,
-        enableFeatures
+        enableFeatures,
       } = await import(`./builtins/${filename}`);
 
       const { component } = await componentize(
@@ -41,14 +42,18 @@ suite('Builtins', () => {
         {
           sourceName: `${name}.js`,
           // also test the debug build while we are about it (unless testing Weval)
-          debugBuild: !enableAot,
+          debugBuild,
           enableFeatures,
           disableFeatures: maybeLogging(disableFeatures),
-          enableAot
+          enableAot,
         }
       );
 
-      const { files } = await transpile(component, { name, wasiShim: true, tracing: DEBUG_TRACING });
+      const { files } = await transpile(component, {
+        name,
+        wasiShim: true,
+        tracing: DEBUG_TRACING,
+      });
 
       await mkdir(new URL(`./output/${name}/interfaces`, import.meta.url), {
         recursive: true,
@@ -101,23 +106,26 @@ suite('Builtins', () => {
                 code === 0 ? resolve() : reject(new Error(stderr || stdout))
               );
               timeout = setTimeout(() => {
-                reject(new Error("test timed out with output:\n" + stdout + '\n\nstderr:\n' + stderr));
+                reject(
+                  new Error(
+                    'test timed out with output:\n' +
+                      stdout +
+                      '\n\nstderr:\n' +
+                      stderr
+                  )
+                );
               }, 10_000);
             });
-          }
-          catch (err) {
+          } catch (err) {
             throw { err, stdout, stderr };
-          }
-          finally {
+          } finally {
             clearTimeout(timeout);
           }
 
           return { stdout, stderr };
         });
-      }
-      catch (err) {
-        if (err.stderr)
-          console.error(err.stderr);
+      } catch (err) {
+        if (err.stderr) console.error(err.stderr);
         throw err.err || err;
       }
     });
@@ -126,8 +134,6 @@ suite('Builtins', () => {
 
 const bindingsCases = await readdir(new URL('./cases', import.meta.url));
 suite('Bindings', () => {
-  const enableAot = process.env.WEVAL_TEST == '1'
-
   for (const name of bindingsCases) {
     test(name, async () => {
       const source = await readFile(
@@ -135,7 +141,10 @@ suite('Bindings', () => {
         'utf8'
       );
 
-      let witWorld, witPath, worldName, isWasiTarget = false;
+      let witWorld,
+        witPath,
+        worldName,
+        isWasiTarget = false;
       try {
         witWorld = await readFile(
           new URL(`./cases/${name}/world.wit`, import.meta.url),
@@ -165,7 +174,9 @@ suite('Bindings', () => {
       const test = await import(`./cases/${name}/test.js`);
 
       const enableFeatures = test.enableFeatures || ['http'];
-      const disableFeatures = test.disableFeatures || (isWasiTarget ? [] : ['random', 'clocks', 'http', 'stdio']);
+      const disableFeatures =
+        test.disableFeatures ||
+        (isWasiTarget ? [] : ['random', 'clocks', 'http', 'stdio']);
 
       let testArg;
       try {
@@ -176,7 +187,8 @@ suite('Bindings', () => {
           worldName,
           enableFeatures,
           disableFeatures: maybeLogging(disableFeatures),
-          enableAot
+          enableAot,
+          debugBuild,
         });
         const map = {
           'wasi:cli-base/*': '@bytecodealliance/preview2-shim/cli-base#*',
@@ -191,19 +203,22 @@ suite('Bindings', () => {
         };
         for (let [impt] of imports) {
           if (impt.startsWith('wasi:')) continue;
-          if (impt.startsWith('['))
-            impt = impt.slice(impt.indexOf(']') + 1);
+          if (impt.startsWith('[')) impt = impt.slice(impt.indexOf(']') + 1);
           let importName = impt.split('/').pop();
           if (importName === 'test') importName = 'imports';
           map[impt] = `../../cases/${name}/${importName}.js`;
         }
 
-        const { files, imports: componentImports, exports: componentExports } = await transpile(component, {
+        const {
+          files,
+          imports: componentImports,
+          exports: componentExports,
+        } = await transpile(component, {
           name,
           map,
           wasiShim: true,
           validLiftingOptimization: false,
-          tracing: DEBUG_TRACING
+          tracing: DEBUG_TRACING,
         });
 
         testArg = { imports, componentImports, componentExports };
@@ -240,8 +255,6 @@ suite('Bindings', () => {
 
 suite('WASI', () => {
   test('basic app', async () => {
-    const enableAot = process.env.WEVAL_TEST == '1'
-
     const { component } = await componentize(
       `
       import { now } from 'wasi:clocks/wall-clock@0.2.3';
@@ -259,7 +272,8 @@ suite('WASI', () => {
       {
         witPath: fileURLToPath(new URL('./wit', import.meta.url)),
         worldName: 'test1',
-        enableAot
+        enableAot,
+        debugBuild,
       }
     );
 

--- a/test/test.js
+++ b/test/test.js
@@ -40,8 +40,8 @@ suite('Builtins', () => {
       `,
         {
           sourceName: `${name}.js`,
-          // also test the debug build while we are about it
-          debugBuild: true,
+          // also test the debug build while we are about it (unless testing Weval)
+          debugBuild: !enableAot,
           enableFeatures,
           disableFeatures: maybeLogging(disableFeatures),
           enableAot

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,11 @@
 interface ComponentizeOptions {
   /**
+   * Use a debug build
+   * Note that the debug build only includes the names section only for size optimization, and not DWARF
+   * debugging sections, due to a lack of support in Node.js for these debugging workflows currently.
+   */
+  debugBuild?: boolean,
+  /**
    * Source name for debugging
    */
   sourceName?: string,


### PR DESCRIPTION
This adds a new `debugBuild: true` option which when enabled uses the debug build that now correctly outputs the names section for Wasm stack traces in V8.

Because we don't currently support DWARF info through the V8 stacks, for now we strip all the debug info so we can still publish the debug build since it is only 13MB.

In future when we can work with the DWARF info, we can revisit this further, along with how the debug build is loaded.

Resolves #137.