### PR TITLE
add version export to types.d.ts

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -89,3 +89,8 @@ interface ComponentizeOutput {
    */
   imports: [[string, string]][]
 }
+
+/**
+ * ComponentizeJS version string
+ */
+export const version: string


### PR DESCRIPTION
This PR adds the missing version export to the `types.d.ts` file.