### PR TITLE
fix: debug build output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(OUTPUT_NAME_DEBUG "starlingmonkey_embedding.debug.wasm")
 set(OUTPUT_NAME_WEVAL "starlingmonkey_embedding_weval.wasm")
 
 # Set the appropriate name based on current configuration
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     set(OUTPUT_FILENAME ${OUTPUT_NAME_DEBUG})
 elseif(WEVAL)
     set(OUTPUT_FILENAME ${OUTPUT_NAME_WEVAL})

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ JCO ?= ./node_modules/.bin/jco
 STARLINGMONKEY_SRC ?= StarlingMonkey
 
 ifndef JCO
-	JCO = $(error No jco in PATH. Run npm install -g @bytecodealliance/jco)
+	JCO = $(error No jco found. Run npm install.)
 endif
 
 # ifndef WASM_OPT
@@ -52,3 +52,4 @@ clean:
 	rm -r obj
 	rm lib/spidermonkey-embedding-splicer.js
 	rm lib/starlingmonkey_embedding.wasm
+	rm lib/starlingmonkey_embedding.debug.wasm


### PR DESCRIPTION
This resolves https://github.com/bytecodealliance/ComponentizeJS/issues/199.

The debug build was not being picked up in the condition to be called `spidermonkey_embedding.debug.wasm` instead overwriting the release build.