### PR TITLE
fix(ci): use a local test server for fetch test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bytecodealliance/componentize-js",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/componentize-js",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "workspaces": [
         "."
       ],

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -8,7 +8,7 @@ import {
 } from '@bytecodealliance/jco';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
-import { resolve, join, dirname } from 'node:path';
+import { join, dirname } from 'node:path';
 import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
 import { rmSync, existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
@@ -17,26 +17,13 @@ import {
   stubWasi,
 } from '../lib/spidermonkey-embedding-splicer.js';
 import { fileURLToPath } from 'node:url';
-import { cwd, stdout, platform } from 'node:process';
+import { cwd, stdout } from 'node:process';
+
+import { maybeWindowsPath } from './platform.js';
+
 export const { version } = JSON.parse(
   await readFile(new URL('../package.json', import.meta.url), 'utf8'),
 );
-const isWindows = platform === 'win32';
-
-function maybeWindowsPath(path) {
-  if (!path) return path;
-  const resolvedPath = resolve(path);
-  if (!isWindows) return resolvedPath;
-
-  // Strip any existing UNC prefix check both the format we add as well as what
-  //  the windows API returns when using path.resolve
-  let cleanPath = resolvedPath;
-  while (cleanPath.startsWith('\\\\?\\') || cleanPath.startsWith('//?/')) {
-    cleanPath = cleanPath.substring(4);
-  }
-
-  return '//?/' + cleanPath.replace(/\\/g, '/');
-}
 
 /**
  * Clean up the given input string by removing the given patterns if

--- a/src/platform.js
+++ b/src/platform.js
@@ -1,0 +1,19 @@
+import { resolve } from 'node:path';
+import { platform } from 'node:process';
+
+export const isWindows = platform === 'win32';
+
+export function maybeWindowsPath(path) {
+  if (!path) return path;
+  const resolvedPath = resolve(path);
+  if (!isWindows) return resolvedPath;
+
+  // Strip any existing UNC prefix check both the format we add as well as what
+  //  the windows API returns when using path.resolve
+  let cleanPath = resolvedPath;
+  while (cleanPath.startsWith('\\\\?\\') || cleanPath.startsWith('//?/')) {
+    cleanPath = cleanPath.substring(4);
+  }
+
+  return '//?/' + cleanPath.replace(/\\/g, '/');
+}

--- a/test/builtins/fetch.js
+++ b/test/builtins/fetch.js
@@ -4,13 +4,11 @@ import { createServer } from 'node:http';
 import { strictEqual, ok } from 'node:assert';
 
 import { maybeWindowsPath } from '../../src/platform.js';
+import { getRandomPort } from '../util.js';
 
 const FETCH_URL = 'http://localhost';
 
 export const state = async () => {
-  const { getRandomPort } = await import(
-    maybeWindowsPath(fileURLToPath(new URL('../util.js', import.meta.url)))
-  );
   const port = await getRandomPort();
   return { port };
 };

--- a/test/builtins/fetch.js
+++ b/test/builtins/fetch.js
@@ -3,11 +3,13 @@ import { createServer } from 'node:http';
 
 import { strictEqual, ok } from 'node:assert';
 
+import { maybeWindowsPath } from '../../src/platform.js';
+
 const FETCH_URL = 'http://localhost';
 
 export const state = async () => {
   const { getRandomPort } = await import(
-    fileURLToPath(new URL('../util.js', import.meta.url))
+    maybeWindowsPath(fileURLToPath(new URL('../util.js', import.meta.url)))
   );
   const port = await getRandomPort();
   return { port };

--- a/test/builtins/fetch.js
+++ b/test/builtins/fetch.js
@@ -8,17 +8,11 @@ import { getRandomPort } from '../util.js';
 
 const FETCH_URL = 'http://localhost';
 
-export const state = async () => {
-  const port = await getRandomPort();
-  return { port };
-};
+const port = await getRandomPort();
 
-export const source = (testState) => {
-  let port = testState?.port ? ':' + testState.port : '';
-  const url = FETCH_URL + port;
-  return `
+export const source = `
   export async function run () {
-    const res = await fetch('${url}');
+    const res = await fetch('${FETCH_URL}:${port}');
     const source = await res.json();
     console.log(source.url);
   }
@@ -26,18 +20,11 @@ export const source = (testState) => {
     return true;
   }
 `;
-};
 
 export const enableFeatures = ['http'];
 
-export async function test(run, testState) {
-  // Get the randomly generated port
-  const port = testState.port;
-  if (!port) {
-    throw new Error('missing port on test state');
-  }
-
-  const url = FETCH_URL + (port ? ':' + port : '');
+export async function test(run) {
+  const url = `${FETCH_URL}:${port}`;
 
   // Run a local server on some port
   const server = createServer(async (req, res) => {

--- a/test/builtins/fetch.js
+++ b/test/builtins/fetch.js
@@ -1,8 +1,24 @@
+import { URL, fileURLToPath } from 'node:url';
+import { createServer } from 'node:http';
+
 import { strictEqual, ok } from 'node:assert';
 
-export const source = `
+const FETCH_URL = 'http://localhost';
+
+export const state = async () => {
+  const { getRandomPort } = await import(
+    fileURLToPath(new URL('../util.js', import.meta.url))
+  );
+  const port = await getRandomPort();
+  return { port };
+};
+
+export const source = (testState) => {
+  let port = testState?.port ? ':' + testState.port : '';
+  const url = FETCH_URL + port;
+  return `
   export async function run () {
-    const res = await fetch('https://httpbin.org/anything');
+    const res = await fetch('${url}');
     const source = await res.json();
     console.log(source.url);
   }
@@ -10,11 +26,45 @@ export const source = `
     return true;
   }
 `;
+};
 
 export const enableFeatures = ['http'];
 
-export async function test(run) {
+export async function test(run, testState) {
+  // Get the randomly generated port
+  const port = testState.port;
+  if (!port) {
+    throw new Error('missing port on test state');
+  }
+
+  const url = FETCH_URL + (port ? ':' + port : '');
+
+  // Run a local server on some port
+  const server = createServer(async (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+    res.write(
+      JSON.stringify({
+        status: 'ok',
+        url,
+      }),
+    );
+    res.end();
+  }).listen(port);
+
+  // Wait until the server is ready
+  let ready = false;
+  while (!ready) {
+    try {
+      const res = await fetch(url);
+      ready = true;
+    } catch (err) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+
   const { stdout, stderr } = await run();
   strictEqual(stderr, '');
-  strictEqual(stdout.trim(), 'https://httpbin.org/anything');
+  strictEqual(stdout.trim(), url);
+
+  server.close();
 }

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,8 @@ const LOG_DEBUGGING = false;
 const enableAot = process.env.WEVAL_TEST == '1';
 const debugBuild = process.env.DEBUG_TEST == '1';
 
+const noOp = async () => {};
+
 function maybeLogging(disableFeatures) {
   if (!LOG_DEBUGGING) return disableFeatures;
   if (disableFeatures && disableFeatures.includes('stdio')) {
@@ -24,12 +26,24 @@ suite('Builtins', () => {
   for (const filename of builtinsCases) {
     const name = filename.slice(0, -3);
     test(name, async () => {
+      const testModule = await import(`./builtins/${filename}`);
       const {
-        source,
+        state,
         test: runTest,
         disableFeatures,
         enableFeatures,
-      } = await import(`./builtins/${filename}`);
+      } = testModule;
+
+      // If an args object was provided, generate the arguments to feed to both
+      // source generation (if necessary) and the test run itself
+      let stateFn = state ?? noOp;
+      const stateObj = await stateFn();
+
+      // If the source is a function then invoke it to generate the source string, possibly with arguments
+      let source = testModule.source;
+      if (typeof source === 'function') {
+        source = source(stateObj);
+      }
 
       const { component } = await componentize(
         source,
@@ -46,7 +60,7 @@ suite('Builtins', () => {
           enableFeatures,
           disableFeatures: maybeLogging(disableFeatures),
           enableAot,
-        }
+        },
       );
 
       const { files } = await transpile(component, {
@@ -61,13 +75,13 @@ suite('Builtins', () => {
 
       await writeFile(
         new URL(`./output/${name}.component.wasm`, import.meta.url),
-        component
+        component,
       );
 
       for (const file of Object.keys(files)) {
         await writeFile(
           new URL(`./output/${name}/${file}`, import.meta.url),
-          files[file]
+          files[file],
         );
       }
 
@@ -76,11 +90,12 @@ suite('Builtins', () => {
         `
         import { run } from './${name}.js';
         run();
-      `
+      `,
       );
 
       try {
-        await runTest(async function run() {
+        // Build a run function to pass to the test
+        const runFn = async function run() {
           let stdout = '',
             stderr = '',
             timeout;
@@ -90,10 +105,10 @@ suite('Builtins', () => {
                 process.argv[0],
                 [
                   fileURLToPath(
-                    new URL(`./output/${name}/run.js`, import.meta.url)
+                    new URL(`./output/${name}/run.js`, import.meta.url),
                   ),
                 ],
-                { stdio: 'pipe' }
+                { stdio: 'pipe' },
               );
               cp.stdout.on('data', (chunk) => {
                 stdout += chunk;
@@ -103,16 +118,16 @@ suite('Builtins', () => {
               });
               cp.on('error', reject);
               cp.on('exit', (code) =>
-                code === 0 ? resolve() : reject(new Error(stderr || stdout))
+                code === 0 ? resolve() : reject(new Error(stderr || stdout)),
               );
               timeout = setTimeout(() => {
                 reject(
                   new Error(
                     'test timed out with output:\n' +
-                    stdout +
-                    '\n\nstderr:\n' +
-                    stderr
-                  )
+                      stdout +
+                      '\n\nstderr:\n' +
+                      stderr,
+                  ),
                 );
               }, 10_000);
             });
@@ -123,7 +138,10 @@ suite('Builtins', () => {
           }
 
           return { stdout, stderr };
-        });
+        };
+
+        // Run the actual test
+        await runTest(runFn, stateObj);
       } catch (err) {
         if (err.stderr) console.error(err.stderr);
         throw err.err || err;
@@ -138,7 +156,7 @@ suite('Bindings', () => {
     test(name, async () => {
       const source = await readFile(
         new URL(`./cases/${name}/source.js`, import.meta.url),
-        'utf8'
+        'utf8',
       );
 
       let witWorld,
@@ -148,14 +166,14 @@ suite('Bindings', () => {
       try {
         witWorld = await readFile(
           new URL(`./cases/${name}/world.wit`, import.meta.url),
-          'utf8'
+          'utf8',
         );
       } catch (e) {
         if (e?.code == 'ENOENT') {
           try {
             isWasiTarget = true;
             witPath = fileURLToPath(
-              new URL(`./cases/${name}/wit`, import.meta.url)
+              new URL(`./cases/${name}/wit`, import.meta.url),
             );
             await readdir(witPath);
           } catch (e) {
@@ -229,14 +247,14 @@ suite('Bindings', () => {
 
         await writeFile(
           new URL(`./output/${name}.component.wasm`, import.meta.url),
-          component
+          component,
         );
 
         for (const file of Object.keys(files)) {
           let source = files[file];
           await writeFile(
             new URL(`./output/${name}/${file}`, import.meta.url),
-            source
+            source,
           );
         }
 
@@ -274,12 +292,12 @@ suite('WASI', () => {
         worldName: 'test1',
         enableAot,
         debugBuild,
-      }
+      },
     );
 
     await writeFile(
       new URL(`./output/wasi.component.wasm`, import.meta.url),
-      component
+      component,
     );
 
     const { files } = await transpile(component, { tracing: DEBUG_TRACING });
@@ -291,7 +309,7 @@ suite('WASI', () => {
     for (const file of Object.keys(files)) {
       await writeFile(
         new URL(`./output/wasi/${file}`, import.meta.url),
-        files[file]
+        files[file],
       );
     }
 
@@ -303,19 +321,17 @@ suite('WASI', () => {
   });
 
   test('basic app (OriginalSourceFile API)', async () => {
-    const { component } = await componentize(
-      {
-        sourcePath: "./test/api/index.js",
-        witPath: fileURLToPath(new URL('./wit', import.meta.url)),
-        worldName: 'test1',
-        enableAot,
-        debugBuild,
-      }
-    );
+    const { component } = await componentize({
+      sourcePath: './test/api/index.js',
+      witPath: fileURLToPath(new URL('./wit', import.meta.url)),
+      worldName: 'test1',
+      enableAot,
+      debugBuild,
+    });
 
     await writeFile(
       new URL(`./output/wasi.component.wasm`, import.meta.url),
-      component
+      component,
     );
 
     const { files } = await transpile(component, { tracing: DEBUG_TRACING });
@@ -327,7 +343,7 @@ suite('WASI', () => {
     for (const file of Object.keys(files)) {
       await writeFile(
         new URL(`./output/wasi/${file}`, import.meta.url),
-        files[file]
+        files[file],
       );
     }
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,13 @@
+import { createServer } from 'node:net';
+
+// Utility function for getting a random port
+export async function getRandomPort() {
+  return await new Promise((resolve) => {
+    const server = createServer();
+    server.listen(0, function () {
+      const port = this.address().port;
+      server.on('close', () => resolve(port));
+      server.close();
+    });
+  });
+}


### PR DESCRIPTION
This test seems to be flaky in CI mostly because it relies on a remote URL.

What I'd *like* to do here is use a server that *we* manage (similar to how `jco` does, moving over some utility functions from there) that will definitely return JS, but it's not clear how the exported `source` was intended to be used (is it OK for that to become a function that takes a URL?).

In the meantime, we can at least retry the test while it depends on a remote URL (and we don't have any testing frameworks like `vitest` set up).