### PR TITLE
fix bug for file paths in windows during componentization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: restore-starlingmonkey-jit-build
         with:
+          enableCrossOsArchive: true
           key: starlingmonkey-${{matrix.build-type}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: lib
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
   ########
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs:
       - build
     strategy:
@@ -141,6 +141,9 @@ jobs:
         node-version:
           - '23.10.0'
           # - latest reenable when https://github.com/nodejs/node/issues/57172 is fixed
+        os:
+          - ubuntu-latest
+          - windows-latest
         build-type:
           - 'release'
           - 'debug'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
         build-type:
           - 'release'
           - 'debug'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bytecodealliance/componentize-js",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/componentize-js",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "workspaces": [
         "."
       ],
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@bytecodealliance/preview2-shim": "^0.17.1",
+        "cross-env": "^7.0.3",
         "mocha": "^11.1.0"
       }
     },
@@ -1091,6 +1092,25 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@bytecodealliance/preview2-shim": "^0.17.1",
+    "cross-env": "^7.0.3",
     "mocha": "^11.1.0"
   },
   "dependencies": {
@@ -31,8 +32,8 @@
     "build:debug": "make debug",
     "test": "mocha -u tdd test/test.js --timeout 120000",
     "test:release": "mocha -u tdd test/test.js --timeout 120000",
-    "test:weval": "WEVAL_TEST=1 mocha -u tdd test/test.js --timeout 120000",
-    "test:debug": "DEBUG_TEST=1 mocha -u tdd test/test.js --timeout 120000",
+    "test:weval": "cross-env WEVAL_TEST=1 mocha -u tdd test/test.js --timeout 120000",
+    "test:debug": "cross-env DEBUG_TEST=1 mocha -u tdd test/test.js --timeout 120000",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/test/cases/missing-export/test.js
+++ b/test/cases/missing-export/test.js
@@ -1,8 +1,9 @@
-import { strictEqual } from 'node:assert';
+import { match } from 'node:assert';
 
+// use match instead of strictEqual to enable testing between linux and windows
+// Windows errors prefix the error with file path
 export function err(e) {
-  strictEqual(e.message, `Unable to extract expected exports list
-Error: "missing-export.js" does not export a "expected" function as expected by the world.
-  Try defining it:
-  export function expected() {};`);
+  match(e.message, /Error: "missing-export.js" does not export a "expected" function/);
+  match(e.message, /Try defining it:/);
+  match(e.message, /export function expected\(\) {};/);
 }


### PR DESCRIPTION
This fixes a bug with the file paths not being passed through `maybeWindowsPath` for the initializer and the source directories. 

fixes #212 