### PR TITLE
Fix building on windows when using new syntax

### DIFF
--- a/src/componentize.js
+++ b/src/componentize.js
@@ -85,8 +85,8 @@ function isNumeric(n) {
 }
 
 export async function componentize(opts,
-                                   _deprecatedWitWorldOrOpts = undefined,
-                                   _deprecatedOpts = undefined) {
+  _deprecatedWitWorldOrOpts = undefined,
+  _deprecatedOpts = undefined) {
   let useOriginalSourceFile = true;
   let jsSource;
 
@@ -246,8 +246,9 @@ export async function componentize(opts,
       workspacePrefix = sourceDir;
       sourcePath = sourceName;
     }
-    if (workspacePrefix.startsWith(cwd())) {
-      workspacePrefix = cwd();
+    let currentDir = maybeWindowsPath(cwd());
+    if (workspacePrefix.startsWith(currentDir)) {
+      workspacePrefix = currentDir;
       sourcePath = sourcePath.slice(workspacePrefix.length + 1);
     }
   }

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -1,0 +1,11 @@
+import { now } from 'wasi:clocks/wall-clock@0.2.3';
+import { getRandomBytes } from 'wasi:random/random@0.2.3';
+
+let result;
+export const run = {
+    run() {
+        result = `NOW: ${now().seconds}, RANDOM: ${getRandomBytes(2n)}`;
+    }
+};
+
+export const getResult = () => result;


### PR DESCRIPTION
The new sytax uses cwd() to strip the prefix when building using original source location. We were not running it through maybeWindowsPath which led to file not being found during initialization. This PR fixes that and thus enables building on windows using the new syntax.