### PR TITLE
fix: do not skip wasi:http export processing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
 defaults:
   run:
     shell: bash
@@ -14,6 +15,7 @@ defaults:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 
 jobs:
   lint:
@@ -33,7 +35,12 @@ jobs:
   #########
 
   build-splicer:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -164,6 +171,15 @@ jobs:
           key: starlingmonkey-${{matrix.build-type}}-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: lib
 
+      - name: Restore Embedding Splicer from cache
+        uses: actions/cache/restore@v4
+        id: splicer-build
+        with:
+          key: splicer-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          path: |
+            lib
+            target
+
       - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
@@ -192,6 +208,15 @@ jobs:
           key: starlingmonkey-release-${{ steps.starlingmonkey-commit.outputs.STARLINGMONKEY_HASH }}
           path: lib
 
+      - name: Restore Embedding Splicer from cache
+        uses: actions/cache/restore@v4
+        id: splicer-build
+        with:
+          key: splicer-${{ hashFiles('Cargo.lock', 'crates/spidermonkey-embedding-splicer/src/**/*.rs') }}
+          path: |
+            lib
+            target
+
       - uses: actions/setup-node@v4
         with:
           node-version: '23.10.0'
@@ -203,8 +228,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: 'examples/hello-world/host/target/release/wasmtime-test*'
-          key: example-hello-world-cargo-${{ hashFiles('examples/hello-world/host/src/main.rs', 
-                                                       'examples/hello-world/host/Cargo.lock', 
+          key: example-hello-world-cargo-${{ hashFiles('examples/hello-world/host/src/main.rs',
+                                                       'examples/hello-world/host/Cargo.lock',
                                                        'examples/hello-world/guest/hello.wit') }}
 
       - name: Test Example

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # WASM_OPT ?= $(shell rm node_modules/.bin/wasm-opt ; which wasm-opt)
-JCO ?= ./node_modules/.bin/jco
+JCO ?= npx jco
 STARLINGMONKEY_SRC ?= StarlingMonkey
 
 ifndef JCO

--- a/crates/spidermonkey-embedding-splicer/src/bindgen.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bindgen.rs
@@ -398,9 +398,6 @@ impl JsBindgen<'_> {
     ) -> Result<()> {
         for (key, export) in &self.resolve.worlds[self.world].exports {
             let name = self.resolve.name_world_key(key);
-            if name.starts_with("wasi:http/incoming-handler@0.2.") {
-                continue;
-            }
             // Do not generate exports when the guest export is not implemented.
             // We check both the full interface name - "ns:pkg@v/my-interface" and the
             // aliased interface name "myInterface". All other names are always

--- a/test/cases/http-server/source.js
+++ b/test/cases/http-server/source.js
@@ -1,0 +1,27 @@
+import {
+  IncomingRequest,
+  ResponseOutparam,
+  OutgoingBody,
+  OutgoingResponse,
+  Fields,
+} from 'wasi:http/types@0.2.3';
+
+export const incomingHandler = {
+  handle(incomingRequest, responseOutparam) {
+    const outgoingResponse = new OutgoingResponse(new Fields());
+    let outgoingBody = outgoingResponse.body();
+    {
+      let outputStream = outgoingBody.write();
+      outputStream.blockingWriteAndFlush(
+        new Uint8Array(new TextEncoder().encode('Hello world!')),
+      );
+      outputStream[Symbol.dispose]();
+    }
+    outgoingResponse.setStatusCode(200);
+    OutgoingBody.finish(outgoingBody, undefined);
+    ResponseOutparam.set(outgoingResponse, {
+      tag: 'ok',
+      val: outgoingResponse,
+    });
+  },
+};

--- a/test/cases/http-server/test.js
+++ b/test/cases/http-server/test.js
@@ -1,0 +1,22 @@
+import { strictEqual } from 'node:assert';
+
+import { HTTPServer } from '@bytecodealliance/preview2-shim/http';
+
+import { getRandomPort } from '../../util.js';
+
+export const enableFeatures = ['http'];
+export const worldName = 'test3';
+
+export async function test(instance) {
+  const server = new HTTPServer(instance.incomingHandler);
+  let port = await getRandomPort();
+  server.listen(port);
+
+  try {
+    const resp = await fetch(`http://localhost:${port}`);
+    const text = await resp.text();
+    strictEqual(text, 'Hello world!');
+  } finally {
+    server.stop();
+  }
+}

--- a/test/wit/test1.wit
+++ b/test/wit/test1.wit
@@ -64,3 +64,10 @@ world test2 {
 
   export get-result: func() -> string;
 }
+
+world test3 {
+  import wasi:cli/environment@0.2.3;
+  import wasi:http/types@0.2.3;
+
+  export wasi:http/incoming-handler@0.2.3;
+}


### PR DESCRIPTION
This commit removes the ignored handling of `wasi:http/incoming-handler` which breaks components that have manually implemented the `handle` export.

This change was introduced during the [recent overhaul](https://github.com/bytecodealliance/ComponentizeJS/pull/202/files#diff-69c4ddcc3664701394605dc159a10360361dc21afeee1a01c967c1f06f1f967aR401), and I got blocked by this trying to upgrade [componentize-js in jco](https://github.com/bytecodealliance/jco/pull/620)