### PR TITLE
fix(ci): workspace path

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -57,7 +57,7 @@ jobs:
             exit 1;
           fi
 
-          export PROJECT_DIR=$PWD;
+          export PROJECT_DIR=${{ github.workspace }};
           export CURRENT_VERSION=$(node -e "process.stdout.write(require(process.env.PROJECT_DIR + '/package.json').version)");
 
           echo -e "project-dir=$PROJECT_DIR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
             exit 1;
           fi
 
-          export PROJECT_DIR=$PWD;
+          export PROJECT_DIR=${{ github.workspace }};
           export CURRENT_VERSION=$(node -e "process.stdout.write(require(process.env.PROJECT_DIR + '/package.json').version)");
           export ARTIFACTS_GLOB="packages/componentize-js/bytecodealliance-componentize-js-*.tgz";
           export ARTIFACT_NAME="bytecodealliance-componentize-js-$NEXT_VERSION.tgz";


### PR DESCRIPTION
As componentize-js isn't a monorepo, `$PWD` includes a trailing slash that throws things off.