### PR TITLE
fix(ci): remove if for JS projects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,6 @@ jobs:
           echo -e "prerelease-tag=$PRERELEASE_TAG" >> $GITHUB_OUTPUT;
 
   pack-npm-release:
-    if: ${{ needs.meta.outputs.is-js-project == 'true' }}
     runs-on: ubuntu-24.04
     needs:
       - meta


### PR DESCRIPTION
This if was preventing the NPM prerelease release from running:

https://github.com/bytecodealliance/ComponentizeJS/actions/runs/15928926959

Once this is gone, the next pre-release should get a GH tag *and* a NPM prerelease