### PR TITLE
fix(ci): add npmrc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       attestations: write
     strategy:
       matrix:
-        rust-version: 
+        rust-version:
           - 1.80.0
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -190,8 +190,11 @@ jobs:
     env:
       PREPACK_SKIP_BUILD: "true"
     steps:
-      # NOTE: we need to checkout to pull npmrc
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Add npmrc
+        run: |
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:


### PR DESCRIPTION
This commit adds the npmrc which utilizes the NPM token provided in CI secrets shortly before performing the NPM publish