### PR TITLE
fix(ci): npm release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          key: node-modules-dev-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package.json') }}
+          key: node-modules-dev-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
           path: |
             node_modules
       - name: Install debug NPM packages
@@ -102,9 +102,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - meta
-    permissions:
-      id-token: write
-      attestations: write
     strategy:
       matrix:
         rust-version:
@@ -133,7 +130,7 @@ jobs:
       - name: Cache npm install
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package.json') }}
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
           path: |
             node_modules
 
@@ -141,25 +138,16 @@ jobs:
         run: |
           npm install
 
-      - name: Perform release build
-        run: |
-          npm run build:release
-
       - name: Create release package
         working-directory: ${{ needs.meta.outputs.project-dir }}
         run: |
           npm pack
 
-      - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
-        with:
-          subject-path: ${{ needs.meta.outputs.artifacts-glob }}
-
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           if-no-files-found: error
-          name: componentize-js
           path: |
-            ${{ needs.meta.outputs.artifacts-glob }}
+            ${{ needs.meta.outputs.artifact-name }}
 
   test-npm-release:
     runs-on: ubuntu-24.04
@@ -176,10 +164,10 @@ jobs:
       - name: Test built componentize-js NPM package
         shell: bash
         run: |
-          export PACKAGE_DIR=${{ github.workspace }}/artifacts/componentize-js/${{ needs.meta.outputs.artifact-name }}
+          export PACKAGE_FILE_PATH=${{ github.workspace }}/artifacts/artifact/${{ needs.meta.outputs.artifact-name }}
           cp -r examples/hello-world/guest /tmp/test
           cd /tmp/test
-          npm install --save $PACKAGE_DIR
+          npm install --save $PACKAGE_FILE_PATH
           npm run all
 
   npm-publish:
@@ -187,10 +175,16 @@ jobs:
     needs:
       - meta
       - test-npm-release
+    permissions:
+      id-token: write
     env:
       PREPACK_SKIP_BUILD: "true"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ">=22"
 
       - name: Add npmrc
         run: |
@@ -205,7 +199,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
         shell: bash
         run: |
-          export PACKAGE_DIR=${{ github.workspace }}/artifacts/componentize-js/${{ needs.meta.outputs.artifact-name }}
+          export PACKAGE_FILE_PATH=${{ github.workspace }}/artifacts/artifact/${{ needs.meta.outputs.artifact-name }}
 
           export OPT_DRY_RUN="--dry-run"
           if [ "tag" == "${{ github.ref_type }}" ]; then
@@ -217,7 +211,14 @@ jobs:
             export OPT_RELEASE_TAG="--tag ${{ needs.meta.outputs.prerelease-tag }}";
           fi
 
-          npm publish -w @bytecodealliance/componentize-js $OPT_DRY_RUN $OPT_RELEASE_TAG $PACKAGE_DIR --access=public
+          npm publish \
+            --verbose \
+            -w @bytecodealliance/componentize-js \
+            --access=public \
+            --provenance \
+            $OPT_DRY_RUN \
+            $OPT_RELEASE_TAG \
+            $PACKAGE_FILE_PATH
 
   create-gh-release:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
While componentize-js packages can be now automatically released, the packages that come out of [the build](https://www.npmjs.com/package/@bytecodealliance/componentize-js/v/0.18.3-rc.3) are missing generated files and GHA attestations don't look like they're being recognized by NPM.

After "local" testing (via another repo), this commit addresses all the issues with the current release CI step. This commit:

- uses package-lock.json for runner cache
- removes a redundant release build
- enables attestation publishing for NPM
- uses more direct artifact name
- requires node version >= 22.x