### PR TITLE
fix: add repository.url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "homepage": "https://github.com/bytecodealliance/componentize-js#readme",
   "description": "ESM -> WebAssembly Component creator, via a SpiderMonkey JS engine embedding",
   "type": "module",
+  "repository": {
+    "url": "https://github.com/bytecodealliance/ComponentizeJS"
+  },
   "bin": {
     "componentize-js": "src/cli.js"
   },


### PR DESCRIPTION
This commit adds repository.url which is required for build attestation

```
 npm http fetch PUT 422 https://registry.npmjs.org/@bytecodealliance%2fcomponentize-js 7837ms
npm verbose stack HttpErrorGeneral: 422 Unprocessable Entity - PUT https://registry.npmjs.org/@bytecodealliance%2fcomponentize-js - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/bytecodealliance/ComponentizeJS" from provenance
npm verbose stack     at /opt/hostedtoolcache/node/22.16.0/x64/lib/node_modules/npm/node_modules/npm-registry-fetch/lib/check-response.js:103:15
npm verbose stack     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
npm verbose stack     at async publish (/opt/hostedtoolcache/node/22.16.0/x64/lib/node_modules/npm/node_modules/libnpmpublish/lib/publish.js:53:15)
npm verbose stack     at async otplease (/opt/hostedtoolcache/node/22.16.0/x64/lib/node_modules/npm/lib/utils/auth.js:8:12)
npm verbose stack     at async #publish (/opt/hostedtoolcache/node/22.16.0/x64/lib/node_modules/npm/lib/commands/publish.js:162:7)
npm verbose stack     at async Publish.exec (/opt/hostedtoolcache/node/22.16.0/x64/lib/node_modules/npm/lib/commands/publish.js:46:5)
npm verbose stack     at async Npm.exec (/opt/hostedtoolcache/node/22.16.0/x64/lib/node_modules/npm/lib/npm.js:207:9)
npm verbose stack     at async module.exports (/opt/hostedtoolcache/node/22.16.0/x64/lib/node_modules/npm/lib/cli/entry.js:74:5)
```

This only happens in *non dry run* mode :confused: 