### PR TITLE
refactor: splicer WIT and generated bindings

### DIFF
--- a/crates/spidermonkey-embedding-splicer/src/bin/splicer.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bin/splicer.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 use std::fs;
 use std::path::PathBuf;
 
-use spidermonkey_embedding_splicer::wit::Features;
+use spidermonkey_embedding_splicer::wit::exports::local::spidermonkey_embedding_splicer::splicer::Features;
 use spidermonkey_embedding_splicer::{splice, stub_wasi};
 
 #[derive(Parser, Debug)]
@@ -70,7 +70,7 @@ enum Commands {
 ///    random,
 ///    http,
 ///}
-fn map_features(features: &Vec<String>) -> Vec<Features> {
+fn map_features(features: &[String]) -> Vec<Features> {
     features
         .iter()
         .map(|f| match f.as_str() {
@@ -78,7 +78,7 @@ fn map_features(features: &Vec<String>) -> Vec<Features> {
             "clocks" => Features::Clocks,
             "random" => Features::Random,
             "http" => Features::Http,
-            _ => panic!("Unknown feature: {}", f),
+            _ => panic!("Unknown feature: {f}"),
         })
         .collect()
 }
@@ -131,13 +131,13 @@ fn main() -> Result<()> {
 
             let result = splice::splice_bindings(engine, world_name, wit_path_str, None, debug)
                 .map_err(|e| anyhow::anyhow!(e))?;
-            fs::write(&out_dir.join("component.wasm"), result.wasm).with_context(|| {
+            fs::write(out_dir.join("component.wasm"), result.wasm).with_context(|| {
                 format!(
                     "Failed to write output file: {}",
                     out_dir.join("component.wasm").display()
                 )
             })?;
-            fs::write(&out_dir.join("initializer.js"), result.js_bindings).with_context(|| {
+            fs::write(out_dir.join("initializer.js"), result.js_bindings).with_context(|| {
                 format!(
                     "Failed to write output file: {}",
                     out_dir.join("initializer.js").display()

--- a/crates/spidermonkey-embedding-splicer/src/stub_wasi.rs
+++ b/crates/spidermonkey-embedding-splicer/src/stub_wasi.rs
@@ -1,5 +1,7 @@
-use crate::parse_wit;
-use crate::wit::Features;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use anyhow::{bail, Result};
 use orca_wasm::ir::function::FunctionBuilder;
 use orca_wasm::ir::id::{FunctionID, LocalID};
@@ -7,13 +9,11 @@ use orca_wasm::ir::module::module_functions::FuncKind;
 use orca_wasm::ir::types::{BlockType, InitExpr, Value};
 use orca_wasm::module_builder::AddLocal;
 use orca_wasm::{DataType, Instructions, Module, Opcode};
-use std::{
-    collections::HashSet,
-    path::PathBuf,
-    time::{SystemTime, UNIX_EPOCH},
-};
 use wasmparser::{MemArg, TypeRef};
 use wit_parser::Resolve;
+
+use crate::parse_wit;
+use crate::wit::exports::local::spidermonkey_embedding_splicer::splicer::Features;
 
 const WASI_VERSIONS: [&str; 4] = ["0.2.0", "0.2.1", "0.2.2", "0.2.3"];
 
@@ -52,7 +52,7 @@ where
 
         return Ok(Some(fid));
     }
-    return Ok(None);
+    Ok(None)
 }
 
 fn stub_import<StubFn>(
@@ -108,7 +108,7 @@ pub fn stub_wasi(
 
         (resolve, ids)
     } else {
-        parse_wit(&PathBuf::from(wit_path.unwrap()))?
+        parse_wit(PathBuf::from(wit_path.unwrap()))?
     };
 
     let world = resolve.select_world(ids, world_name.as_deref())?;

--- a/crates/spidermonkey-embedding-splicer/src/wit.rs
+++ b/crates/spidermonkey-embedding-splicer/src/wit.rs
@@ -1,0 +1,23 @@
+use anyhow::{bail, Result};
+
+wit_bindgen::generate!({
+    world: "spidermonkey-embedding-splicer",
+    pub_export_macro: true
+});
+
+use crate::wit::exports::local::spidermonkey_embedding_splicer::splicer::Features;
+
+impl std::str::FromStr for Features {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "stdio" => Ok(Features::Stdio),
+            "clocks" => Ok(Features::Clocks),
+            "random" => Ok(Features::Random),
+            "http" => Ok(Features::Http),
+            "fetch-event" => Ok(Features::FetchEvent),
+            _ => bail!("unrecognized feature string [{s}]"),
+        }
+    }
+}

--- a/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
+++ b/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
@@ -1,6 +1,6 @@
 package local:spidermonkey-embedding-splicer;
 
-world spidermonkey-embedding-splicer {
+interface splicer {
   enum core-ty {
     i32,
     i64,
@@ -13,6 +13,7 @@ world spidermonkey-embedding-splicer {
     clocks,
     random,
     http,
+    fetch-event,
   }
 
   record core-fn {
@@ -30,7 +31,31 @@ world spidermonkey-embedding-splicer {
     imports: list<tuple<string, string, u32>>,
   }
 
-  export stub-wasi: func(engine: list<u8>, features: list<features>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>) -> result<list<u8>, string>;
+  /// Stub the WASI imports/exports of a given JS engine WebAssembly module
+  ///
+  /// Depending on which features have been enabled, different default-provided WASI
+  /// imports may be stubbed (for example to be made unreachable).
+  stub-wasi: func(
+      engine: list<u8>,
+      features: list<features>,
+      wit-world: option<string>,
+      wit-path: option<string>,
+      world-name: option<string>
+  ) -> result<list<u8>, string>;
 
-  export splice-bindings: func(spidermonkey-engine: list<u8>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>, debug: bool) -> result<splice-result, string>;
+  /// Splice blindings for a given WIT world into the spider monkey engine binary (spidermonkey.wasm)
+  /// this function produces a new WebAssembly component
+  splice-bindings: func(
+      spidermonkey-engine: list<u8>,
+      features: list<features>,
+      wit-world: option<string>,
+      wit-path: option<string>,
+      world-name: option<string>,
+      debug: bool,
+  ) -> result<splice-result, string>;
+
+}
+
+world spidermonkey-embedding-splicer {
+  export splicer;
 }

--- a/crates/splicer-component/src/lib.rs
+++ b/crates/splicer-component/src/lib.rs
@@ -1,6 +1,7 @@
 use spidermonkey_embedding_splicer::stub_wasi::stub_wasi;
-use spidermonkey_embedding_splicer::wit::{export, Features, Guest, SpliceResult};
-use spidermonkey_embedding_splicer::{splice, wit};
+use spidermonkey_embedding_splicer::wit::{self, export};
+use spidermonkey_embedding_splicer::splice;
+use spidermonkey_embedding_splicer::wit::exports::local::spidermonkey_embedding_splicer::splicer::{Features, Guest, SpliceResult};
 
 struct SpidermonkeyEmbeddingSplicerComponent;
 
@@ -17,6 +18,7 @@ impl Guest for SpidermonkeyEmbeddingSplicerComponent {
 
     fn splice_bindings(
         engine: Vec<u8>,
+        _features: Vec<Features>,
         world_name: Option<String>,
         wit_path: Option<String>,
         wit_source: Option<String>,


### PR DESCRIPTION
This commit refactors the WIT for the splicer, and moves the generated bindings to their own module file which is likely a bit easier to grok for most, and a good place to put extra functionality (e.g. custom impls for the generated types).

The code from this pr is split out from #247 for easy reviewing