### PR TITLE
fix: embedding splicer error handling

### DIFF
--- a/crates/spidermonkey-embedding-splicer/src/bindgen.rs
+++ b/crates/spidermonkey-embedding-splicer/src/bindgen.rs
@@ -859,9 +859,7 @@ impl JsBindgen<'_> {
             }
         }
 
-        let err = if get_result_types(self.resolve, func.result)
-            .is_some_and(|(_, err_ty)| err_ty.is_some())
-        {
+        let err = if get_result_types(self.resolve, func.result).is_some() {
             match abi {
                 AbiVariant::GuestExport => ErrHandling::ThrowResultErr,
                 AbiVariant::GuestImport => ErrHandling::ResultCatchHandler,

--- a/test/cases/http-request/source.js
+++ b/test/cases/http-request/source.js
@@ -32,9 +32,9 @@ export function getResult() {
 
   let responseBody;
 
-  const incomingBody = incomingResponse.consume().val;
+  const incomingBody = incomingResponse.consume();
   {
-    const bodyStream = incomingBody.stream().val;
+    const bodyStream = incomingBody.stream();
     // const bodyStreamPollable = bodyStream.subscribe();
     const buf = bodyStream.blockingRead(500n);
     // TODO: actual streaming

--- a/test/cases/http-server/source.js
+++ b/test/cases/http-server/source.js
@@ -9,9 +9,9 @@ import {
 export const incomingHandler = {
   handle(incomingRequest, responseOutparam) {
     const outgoingResponse = new OutgoingResponse(new Fields());
-    let outgoingBody = outgoingResponse.body().val;
+    let outgoingBody = outgoingResponse.body();
     {
-      let outputStream = outgoingBody.write().val;
+      let outputStream = outgoingBody.write();
       outputStream.blockingWriteAndFlush(
         new Uint8Array(new TextEncoder().encode('Hello world!')),
       );


### PR DESCRIPTION
This commit fixes a regression in function generation when error handling is involved.

The buggy code over-eagerly checks whether there is an error type type present on a result, when there may legitimately not be (e.g. `result<t>` in WIT). The fix is to check *only* for whether the types are returned as a pair (indicating a `result`) at all.