### PR TITLE
fix(ci): release changelog generation

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -97,16 +97,19 @@ jobs:
         run: |
           export IS_PRERELEASE=$(node scripts/semver-is-prerelease.mjs ${{ steps.project-meta.outputs.next-version }});
 
-          export START_ARG="--latest";
+          export OPT_TAG=--tag=${{ steps.project-meta.outputs.next-version }};
+
+          export OPT_TAG_PATTERN=--tag-pattern='^[0-9]+.[0-9]+.[0-9]+$';
           if [ "true" == "$IS_PRERELEASE" ]; then
-            export START_ARG="--unreleased";
+            export OPT_TAG_PATTERN=--tag-pattern='^[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?';
           fi
 
           git cliff \
             --repository=${{ github.workspace }}/.git \
             --config=./cliff.toml \
-            $START_ARG \
-            --tag=${{ steps.project-meta.outputs.next-version }} \
+            --unreleased \
+            $OPT_TAG \
+            $OPT_TAG_PATTERN \
             --prepend=CHANGELOG.md
 
       # Create release PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,15 +250,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}
         run: |
+          export OPT_START=--unreleased;
+          export OPT_TAG=;
           if [ "tag" == "${{ github.ref_type }}" ]; then
-            git cliff --repository=${{ github.workspace }}/.git --latest > CHANGELOG.current;
-          else
-            git cliff \
-              --repository=${{ github.workspace }}/.git \
-              --unreleased \
-              --tag=${{ needs.meta.outputs.next-release-tag }} \
-              > CHANGELOG.current;
+            export OPT_START=--current;
+            export OPT_TAG=--tag=${{ needs.meta.outputs.next-release-tag }};
           fi
+
+          export OPT_TAG_PATTERN=--tag-pattern='^[0-9]+.[0-9]+.[0-9]+$';
+          if [ "true" == "${{ needs.meta.outputs.is-prerelease }}" ]; then
+            export OPT_TAG_PATTERN=--tag-pattern='^[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?';
+          fi
+
+          git cliff \
+            --repository=${{ github.workspace }}/.git \
+            --config=./cliff.toml \
+            $OPT_START \
+            $OPT_TAG \
+            $OPT_TAG_PATTERN \
+            > CHANGELOG.current;
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/cliff.toml
+++ b/cliff.toml
@@ -74,14 +74,4 @@ topo_order = false
 sort_commits = "newest"
 
 # glob pattern for matching git tags
-tag_pattern = "^[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?"
-
-# regex for skipping tags
-#
-# NOTE: we don't skip taks for beta/rc/alpha since we want their features
-# to be included in the next stable release
-#
-#skip_tags = "beta|rc|alpha"
-
-# tags to ignore
-ignore_tags = "beta|rc|alpha"
+tag_pattern = "^[0-9]+.[0-9]+.[0-9]+$"


### PR DESCRIPTION
This commit fixes the changelog generation by overriding tag pattern depending on whether we're in a pre-release or not.

In the past, pre-release changelogs included too many changes and the release changes included *not enough*.