### PR TITLE
fix(ci): create rc releases as prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           token: ${{ secrets.RELEASE_PAT || github.token }}
-          prerelease: ${{ github.ref_type != 'tag' }}
+          prerelease: ${{ github.ref_type != 'tag' || needs.meta.outputs.is-prerelease == 'true' }}
           draft: ${{ github.ref_type != 'tag' }}
           tag_name: ${{ needs.meta.outputs.next-release-tag }}
           generate_release_notes: false


### PR DESCRIPTION
Right now RC releases show up as regular releases -- it'd be better if we showed them as prereleases.