### PR TITLE
fix(tests): race condition with server random port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "@bytecodealliance/componentize-js",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/componentize-js",
-      "version": "0.18.4",
+      "version": "0.18.5",
       "workspaces": [
         "."
       ],
       "dependencies": {
         "@bytecodealliance/jco": "^1.9.1",
-        "@bytecodealliance/weval": "^0.3.4",
         "@bytecodealliance/wizer": "^10.0.0",
         "es-module-lexer": "^1.6.0",
         "oxc-parser": "^0.76.0"
@@ -21,7 +20,7 @@
         "componentize-js": "src/cli.js"
       },
       "devDependencies": {
-        "@bytecodealliance/preview2-shim": "^0.17.1",
+        "@bytecodealliance/preview2-shim": "^0.17.4",
         "cross-env": "^7.0.3",
         "semver": "^7.7.2",
         "vitest": "^3.2.4"
@@ -184,9 +183,9 @@
       }
     },
     "node_modules/@bytecodealliance/preview2-shim": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.1.tgz",
-      "integrity": "sha512-h1qLL0TN5KXk/zagY2BtbZuDX6xYjz4Br9RZXEa0ID4UpiPc0agUMhTdz9r89G4vX5SU/tqBg1A6UNv2+DJ5pg==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.4.tgz",
+      "integrity": "sha512-vRfxQ6ob5wCgXlpVNoeIUHrqJ2+JTcnQASNMpoi3OVPRYA2oUfhMJdWFP0u5JVL9FlC4YKe+QKqerr345B3T4A==",
       "license": "(Apache-2.0 WITH LLVM-exception)"
     },
     "node_modules/@bytecodealliance/weval": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "import": "./src/componentize.js"
   },
   "devDependencies": {
-    "@bytecodealliance/preview2-shim": "^0.17.1",
+    "@bytecodealliance/preview2-shim": "^0.17.4",
     "cross-env": "^7.0.3",
     "semver": "^7.7.2",
     "vitest": "^3.2.4"

--- a/test/cases/fetch-event-server/test.js
+++ b/test/cases/fetch-event-server/test.js
@@ -2,8 +2,6 @@ import { strictEqual } from 'node:assert';
 
 import { HTTPServer } from '@bytecodealliance/preview2-shim/http';
 
-import { getRandomPort } from '../../util.js';
-
 export const enableFeatures = ['http', 'fetch-event'];
 export const worldName = 'test3';
 
@@ -11,8 +9,8 @@ export async function test(instance) {
   let server;
   try {
     server = new HTTPServer(instance.incomingHandler);
-    let port = await getRandomPort();
-    server.listen(port);
+    server.listen(0);
+    const { port } = server.address();
     const resp = await fetch(`http://localhost:${port}`);
     const text = await resp.text();
     strictEqual(text, 'Hello World');

--- a/test/cases/http-server/test.js
+++ b/test/cases/http-server/test.js
@@ -11,8 +11,8 @@ export async function test(instance) {
   let server;
   try {
     server = new HTTPServer(instance.incomingHandler);
-    let port = await getRandomPort();
-    server.listen(port);
+    server.listen(0);
+    const { port } = server.address();
     const resp = await fetch(`http://localhost:${port}`);
     const text = await resp.text();
     strictEqual(text, 'Hello world!');

--- a/test/util.js
+++ b/test/util.js
@@ -11,18 +11,6 @@ function isEnabledEnvVar(v) {
   );
 }
 
-// Utility function for getting a random port
-export async function getRandomPort() {
-  return await new Promise((resolve) => {
-    const server = createServer();
-    server.listen(0, function () {
-      const port = this.address().port;
-      server.on('close', () => resolve(port));
-      server.close();
-    });
-  });
-}
-
 export function maybeLogging(disableFeatures) {
   if (!LOG_DEBUGGING_ENABLED) return disableFeatures;
   if (disableFeatures && disableFeatures.includes('stdio')) {


### PR DESCRIPTION
This commit updates the tests that used `getRandomPort()` to perform their own random port getting and use the generated servers where appropriate, fixing a race condition on acquiring a temporary server port.

To be able to use `HTTPServer` instances with os-provided random ports from `@bytecodealliance/preview2-shim`, this PR updates updates the dev-dependency on preview2-shim to 0.17.4.

Resolves #287 