### PR TITLE
Fix memory leak in call() retptr allocation

### DIFF
--- a/embedding/embedding.cpp
+++ b/embedding/embedding.cpp
@@ -232,7 +232,7 @@ __attribute__((export_name("call"))) uint32_t call(uint32_t fn_idx,
   void *retptr = nullptr;
   if (fn->retptr) {
     LOG("(call) setting retptr at arg %d\n", argcnt);
-    retptr = JS_realloc(Runtime.cx, 0, 0, fn->retsize);
+    retptr = cabi_realloc(nullptr, 0, 4, fn->retsize);
     args[argcnt].setInt32((uint32_t)retptr);
   }
 


### PR DESCRIPTION
JavaScript components leak memory when returning non-primitive types (strings, objects, arrays, etc.). 

### Cause
Return pointer allocation used `JS_realloc` which bypasses memory tracking, so allocations were never freed.

### Fix
Use `cabi_realloc` instead to ensure proper tracking and cleanup.

-----

### Before:
RES memory leaks indefinitely as can be seen in repro provided in #279:
```
Loading js component from: /home/ludde/leak/runner/../component/js/handler.wasm
Finished compiling component
Testing string echo (should leak)...
String Iteration: 0, Virtual: 5218636 KB, RES: 785404 KB
String Iteration: 500000, Virtual: 5218896 KB, RES: 838668 KB
String Iteration: 1000000, Virtual: 5218896 KB, RES: 845532 KB
String Iteration: 1500000, Virtual: 5218896 KB, RES: 852132 KB
String Iteration: 2000000, Virtual: 5218896 KB, RES: 855828 KB
String Iteration: 2500000, Virtual: 5218896 KB, RES: 862428 KB
String Iteration: 3000000, Virtual: 5218896 KB, RES: 870348 KB
String Iteration: 3500000, Virtual: 5218896 KB, RES: 878796 KB
String Iteration: 4000000, Virtual: 5218896 KB, RES: 886188 KB
String Iteration: 4500000, Virtual: 5218896 KB, RES: 893580 KB
String Iteration: 5000000, Virtual: 5218896 KB, RES: 902028 KB
.
.
.
String Iteration: 17000000, Virtual: 5218896 KB, RES: 1089204 KB
...
```


### After:
RES memory stabilizes after X guest call iterations:
```
Loading js component from: /home/ludde/leak/runner/../component/js/handler.wasm
Finished compiling component
Testing string echo (should leak)...
String Iteration: 0, Virtual: 5349704 KB, RES: 779232 KB
String Iteration: 500000, Virtual: 5349964 KB, RES: 821192 KB
String Iteration: 1000000, Virtual: 5349964 KB, RES: 821192 KB
String Iteration: 1500000, Virtual: 5349964 KB, RES: 821192 KB
String Iteration: 2000000, Virtual: 5349964 KB, RES: 821192 KB
String Iteration: 2500000, Virtual: 5349964 KB, RES: 821192 KB
String Iteration: 3000000, Virtual: 5349964 KB, RES: 821192 KB
String Iteration: 3500000, Virtual: 5349964 KB, RES: 821192 KB
String Iteration: 4000000, Virtual: 5349964 KB, RES: 821192 KB
String Iteration: 4500000, Virtual: 5349964 KB, RES: 821192 KB
String Iteration: 5000000, Virtual: 5349964 KB, RES: 821192 KB
...
```

Closes #279 