### PR TITLE
fix(ci): temporarily downgrade windows runners from latest to 2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,8 @@ jobs:
           # - latest reenable when https://github.com/nodejs/node/issues/57172 is fixed
         os:
           - ubuntu-latest
-          - windows-latest
+          # NOTE: windows-2025 (which is now latest) seems to hang on test runs
+          - windows-2022
           - macos-latest
         build-type:
           - 'release'


### PR DESCRIPTION
After GitHub's change of the default windows runner it looks like componentize-js tests hang. While we should absoltuely fix/root-cause the windows issue, in the meantime this commit gets CI completing again.