### PR TITLE
fix: remove shell setting for wizer call

### DIFF
--- a/src/componentize.js
+++ b/src/componentize.js
@@ -257,8 +257,8 @@ export async function componentize(
   let args = `--initializer-script-path ${initializerPath} --strip-path-prefix ${workspacePrefix}/ ${sourcePath}`;
   runtimeArgs = runtimeArgs ? `${runtimeArgs} ${args}` : args;
 
-  let preopens = [`--dir ${sourcesDir}`];
-  preopens.push(`--mapdir /::${workspacePrefix}`);
+  let preopens = [`--dir=${sourcesDir}`];
+  preopens.push(`--mapdir=/::${workspacePrefix}`);
 
   let postProcess;
 
@@ -279,7 +279,6 @@ export async function componentize(
       stdio: [null, stdout, 'pipe'],
       env,
       input: runtimeArgs,
-      shell: true,
       encoding: 'utf-8',
     },
   );


### PR DESCRIPTION
This commit removes the `shell: true` configuration for the Wizer call, as it triggers a warning with more recent NodeJS versions, due to attempting to pass options to an spawned command when `shell: true`...

For reference the deprecation warning looks like this:

```
(node:2921631) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

We don't actually use user submitted args directly so we weren't really at risk of this, but better to have this not show up.