### PR TITLE
fix(ci): test runs on windows runner

### DIFF
--- a/test/builtins.js
+++ b/test/builtins.js
@@ -19,12 +19,15 @@ suite('Builtins', async () => {
   for (const filename of builtins) {
     const name = filename.slice(0, -3);
     test.concurrent(name, async () => {
+      // NOTE: import separated from await due to issues on windows (see note in util.js)
+      const builtinModulePromise = import(`./builtins/${name}.js`);
+
       const {
         source,
         test: runTest,
         disableFeatures,
         enableFeatures,
-      } = await import(`./builtins/${name}.js`);
+      } = await builtinModulePromise;
 
       const { component } = await componentize(
         source,

--- a/test/util.js
+++ b/test/util.js
@@ -56,10 +56,21 @@ export async function setupComponent(opts) {
   }
 
   const componentJsPath = join(wasiDir, 'component.js');
-  var instance = await import(componentJsPath);
 
-  return {
-    instance,
-    outputDir,
-  };
+  // NOTE: On Windows, vitest has stated suddenly hanging when processing code with an
+  // `await import(...)` in it, when the `...` is a bare identifier.
+  //
+  // This can be worked around in many ways:
+  // - doing a trivial tranformation on the identifier/argument
+  // - returning a more traditional promise
+  // - separating await and import() calls
+  //
+  // Here we choose to return the promise more traditionally
+  return import(componentJsPath)
+    .then(instance => {
+        return {
+            instance,
+            outputDir,
+        };
+    });
 }


### PR DESCRIPTION
This commit fixes an somewhat odd problem with vitest on windows runners in that it cannot process properly `await import(...)` statements.

The changes in this commit represent the minimal changes to make the tests run properly instead of hanging, though there are other improvements to CI forthcoming.